### PR TITLE
feat(tuned): Added tuned package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lockwobr @mskalka @ayuskauskas
+* @lockwobr @mskalka @ayuskauskas @riceriley59

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ A specialized package for system-level tuning and configuration management.
 - `ulimit.conf` - User limits (immediate effect + container limits on reboot)
 - `service_{name}.conf` - Systemd service configurations (requires service restart)
 
+### 3. Tuned Package (`tuned/`)
+A package for managing the tuned system tuning daemon on Linux systems for automated performance optimization.
+
+**Capabilities:**
+- Multi-distribution support (Ubuntu/Debian, CentOS/RHEL/Amazon Linux, Fedora)
+- Automated tuned package installation and service management
+- Custom tuned profile deployment via configmaps
+- Built-in profile validation and verification
+- Handles necessary interrupts for tuning parameters that require reboots/restarts
+- Comprehensive installation and configuration validation
+
+**Key features:**
+- Deploy custom tuned profiles from configmaps
+- Apply system-wide performance tuning profiles
+- Automatic service lifecycle management (install, configure, validate, uninstall)
+- Support for built-in profiles (balanced, powersave, throughput-performance, etc.)
+- Idempotent operations safe for repeated execution
+
 ## Package Structure
 
 Each package follows the standard skyhook package structure:
@@ -168,7 +186,10 @@ This validation step is crucial as the agent uses JSON schema validation to ensu
 
 ## Getting Started
 
-1. **Choose a package** that fits your use case (shellscript for custom scripts, tuning for system configuration)
+1. **Choose a package** that fits your use case:
+   - `shellscript` for custom scripts and automation
+   - `tuning` for system-level configuration management  
+   - `tuned` for automated performance tuning with the tuned daemon
 2. **Review the package README** for specific usage instructions and examples
 3. **Create a Skyhook Custom Resource** referencing the package
 4. **Apply the SCR** to your cluster and monitor the package deployment
@@ -179,6 +200,7 @@ This validation step is crucial as the agent uses JSON schema validation to ensu
 - [Package Lifecycle Documentation](./PACKAGE_LIFECYCLE.md) - Comprehensive guide to package lifecycle stages
 - [Shellscript Package](./shellscript/README.md) - Usage guide for the shellscript package
 - [Tuning Package](./tuning/README.md) - Usage guide for the tuning package
+- [Tuned Package](./tuned/README.md) - Usage guide for the tuned package
 - [NVIDIA Skyhook Documentation](https://github.com/NVIDIA/skyhook) - Main skyhook operator documentation
 
 ## Contributing

--- a/tuned/Dockerfile
+++ b/tuned/Dockerfile
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox:latest
+
+RUN mkdir -p /skyhook-package/skyhook_dir
+COPY . /skyhook-package

--- a/tuned/README.md
+++ b/tuned/README.md
@@ -1,0 +1,255 @@
+# Tuned Package
+
+A Skyhook package for managing the `tuned` system tuning daemon on Linux systems. This package provides automated installation, configuration, and management of tuned profiles for system performance optimization.
+
+## Overview
+
+[Tuned](https://github.com/redhat-performance/tuned) is a daemon that uses udev to monitor connected devices and statically and dynamically tunes system settings according to a selected profile. This package automates the deployment and configuration of tuned across different Linux distributions.
+
+## Features
+
+- **Multi-distribution support**: Works on Ubuntu/Debian, CentOS/RHEL/Amazon Linux, and Fedora
+- **Custom profile management**: Deploy and apply custom tuned profiles via configmaps
+- **Idempotent operations**: Safe to run multiple times without side effects
+- **Comprehensive validation**: Built-in checks for installation and configuration status
+- **Service lifecycle management**: Handles installation, configuration, and uninstallation
+- **Handles Necessary Interrupts**: Handles reboots and service restarts around important workloads for specific tuning parameters that require it.
+
+## Package Structure
+
+```
+tuned/
+├── config.json                           # Skyhook package configuration
+├── README.md                            # This file
+├── Dockerfile                           # Container build file
+└── skyhook_dir/
+    ├── install_tuned.sh                 # Install tuned package and service
+    ├── install_tuned_check.sh           # Validate tuned installation
+    ├── uninstall_tuned.sh               # Remove tuned package and service
+    ├── uninstall_tuned_check.sh         # Validate tuned removal
+    ├── apply_tuned_profile.sh           # Apply tuned profiles from configmaps
+    ├── apply_tuned_profile_check.sh     # Validate profile configuration
+    └── post_interrupt_tuned_check.sh    # Validate post-interruption state
+```
+
+## Supported Operating Systems
+
+- **Ubuntu/Debian**: Uses `apt` package manager
+- **CentOS/RHEL/Amazon Linux**: Uses `yum` package manager
+- **Fedora**: Uses `dnf` package manager
+
+## Package Modes
+
+### Installation Modes
+
+#### `apply` / `upgrade`
+- **Script**: `install_tuned.sh`
+- **Purpose**: Installs the tuned package and starts/enables the service
+- **Actions**:
+  - Updates package repositories
+  - Installs tuned package
+  - Enables and starts tuned service
+  - Displays service status
+
+#### `apply-check` / `upgrade-check`
+- **Script**: `install_tuned_check.sh`
+- **Purpose**: Validates successful tuned installation
+- **Checks**:
+  - `tuned` command availability
+  - `tuned-adm` command availability
+  - Service is running (`systemctl is-active`)
+  - Service is enabled for boot (`systemctl is-enabled`)
+
+### Configuration Mode
+
+#### `config`
+- **Script**: `apply_tuned_profile.sh`
+- **Purpose**: Deploys custom profiles and applies the specified tuned profile
+- **Process**:
+  1. Creates custom profile directories in `/etc/tuned/`
+  2. Copies configmap files as `tuned.conf` for each custom profile
+  3. Reads the target profile from `tuned_profile` configmap file
+  4. Applies the specified profile using `tuned-adm profile`
+
+#### `config-check`
+- **Script**: `apply_tuned_profile_check.sh`
+- **Purpose**: Validates profile configuration
+- **Checks**:
+  - Tuned service is running
+  - Configmaps directory exists
+  - Custom profiles are properly deployed
+  - Correct profile is active and verified
+  - Profile verification via `tuned-adm verify` (behavior controlled by `INTERRUPT` variable)
+
+### Uninstallation Mode
+
+#### `uninstall`
+- **Script**: `uninstall_tuned.sh`
+- **Purpose**: Removes tuned package and disables service
+- **Actions**:
+  - Disables and stops tuned service
+  - Removes tuned package
+  - Cleans up unused dependencies (apt only)
+
+#### `uninstall-check`
+- **Script**: `uninstall_tuned_check.sh`
+- **Purpose**: Validates successful tuned removal
+- **Checks**:
+  - `tuned` command is not available
+  - `tuned-adm` command is not available
+  - Service is stopped
+  - Service is disabled
+
+## Recovery Mode
+
+#### `post-interrupt-check`
+- **Script**: `post_interrupt_tuned_check.sh`
+- **Purpose**: Validates system state after interrupt (reboot/service restart)
+- **Checks**: Performs comprehensive validation of tuned state, including mandatory `tuned-adm verify` (always enforced regardless of `INTERRUPT` variable)
+
+## Configuration
+
+### Environment Variables
+
+#### INTERRUPT
+
+The `INTERRUPT` environment variable controls how the package handles `tuned-adm verify` failures during different validation phases:
+
+- **Purpose**: Determines whether to fail on `tuned-adm verify` errors in the config-check step
+- **Values**:
+  - `true`: Allow config-check to pass even if `tuned-adm verify` fails (recommended for tunings requiring an interrupt)
+  - `false` or unset: Fail config-check if `tuned-adm verify` fails (default behavior)
+- **When to use**: Set to `true` when applying tuning profiles that require an interrupt to take effect and verify correctly
+- **Behavior**:
+  - **config-check step**: If `INTERRUPT=true`, verification failures are logged as warnings but don't cause the step to fail
+  - **post-interrupt-check step**: Always fails on verification errors regardless of INTERRUPT setting (tunings should be verifiable after an interrupt)
+
+**Example configuration in SCR:**
+```yaml
+env:
+    name: INTERRUPT
+    value: true
+```
+
+### Configmaps
+
+The package expects configmaps to be available in `${SKYHOOK_DIR}/configmaps/`:
+
+#### Required Configmaps
+
+- **`tuned_profile`**: Contains the name of the tuned profile to apply
+  ```
+  # Example content
+  balanced
+  ```
+
+#### Optional Configmaps
+
+- **Custom profile files**: Any other files in the configmaps directory will be treated as custom tuned profile configurations
+  - File name becomes the profile name
+  - File contents become the `tuned.conf` for that profile
+  - Files are deployed to `/etc/tuned/<profile_name>/tuned.conf`
+
+### Example Custom Profile
+
+```ini
+# configmaps/my-custom-profile
+[main]
+summary=Custom performance profile for my application
+
+[cpu]
+governor=performance
+energy_perf_bias=performance
+
+[disk]
+readahead=4096
+
+[vm]
+transparent_hugepages=never
+```
+
+## Usage Examples
+
+### Basic Installation
+Deploy the package with apply mode to install tuned with default settings.
+
+### Custom Profile Deployment
+1. Create configmap files with your custom tuned profiles
+2. Create a `tuned_profile` configmap specifying which profile to activate
+3. Deploy the package with config mode to apply the custom configuration
+
+### Available Tuned Profiles
+
+Common built-in profiles include:
+- `balanced` - Default balanced profile
+- `powersave` - Power saving profile
+- `throughput-performance` - Maximum throughput
+- `latency-performance` - Low latency optimization
+- `network-latency` - Network latency optimization
+- `network-throughput` - Network throughput optimization
+
+Use `tuned-adm list` to see all available profiles on your system or go to [tuned profiles](https://github.com/redhat-performance/tuned/tree/master/profiles) to see the profiles which are automatically installed with tuned.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Service fails to start**
+   - Check system logs: `journalctl -u tuned`
+   - Verify package installation: `rpm -q tuned` or `dpkg -l tuned`
+
+2. **Profile not found**
+   - List available profiles: `tuned-adm list`
+   - Check custom profile deployment in `/etc/tuned/`
+
+3. **Permission errors**
+   - Ensure scripts run with appropriate privileges
+   - Check `/etc/tuned/` directory permissions
+
+4. **Verification errors**
+   - Check verification: `tuned-adm verify`
+   - Verify correct active profile: `tuned-adm active`
+   - Check verification logs in `/var/log/tuned/tuned.log`
+   - For tunings requiring reboot: Set `INTERRUPT=true` to allow config-check to pass despite verification failures
+
+### Validation Commands
+
+```bash
+# Check tuned status
+systemctl status tuned
+
+# List available profiles
+tuned-adm list
+
+# Check active profile
+tuned-adm active
+
+# Verify profile recommendations
+tuned-adm recommend
+
+# Verify tuning has finished
+tuned-adm verify
+```
+
+## Dependencies
+
+- **System Requirements**: Linux with systemd
+- **Package Managers**: apt, yum, or dnf
+- **Runtime Dependencies**:
+  - `systemctl` (systemd)
+  - `sudo` (for profile management)
+
+## Version
+
+- **Package Version**: 1.0.0
+- **Schema Version**: v1
+
+## Contributing
+
+When modifying this package:
+
+1. Ensure all scripts maintain idempotency
+2. Add appropriate error handling and validation
+3. Update both action and check scripts for new functionality
+4. Test across all supported distributions
+5. Update this README with any new features or requirements

--- a/tuned/config.json
+++ b/tuned/config.json
@@ -1,0 +1,139 @@
+{
+    "schema_version": "v1",
+    "package_name": "tuned",
+    "package_version": "1.0.0",
+    "expected_config_files": [],
+    "modes": {
+        "uninstall": [
+            {
+                "name": "uninstall",
+                "path": "uninstall_tuned.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "uninstall-check": [
+            {
+                "name": "uninstall-check",
+                "path": "uninstall_tuned_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+
+        ],
+        "upgrade": [
+            {
+                "name": "upgrade",
+                "path": "install_tuned.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+
+        ],
+        "upgrade-check": [
+            {
+                "name": "upgrade-check",
+                "path": "install_tuned_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+
+        ],
+        "apply": [
+            {
+                "name": "apply",
+                "path": "install_tuned.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+
+        ],
+        "apply-check": [
+            {
+                "name": "apply-check",
+                "path": "install_tuned_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+
+        ],
+        "config": [
+            {
+                "name": "config",
+                "path": "apply_tuned_profile.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "config-check": [
+            {
+                "name": "config-check",
+                "path": "apply_tuned_profile_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "post-interrupt-check": [
+            {
+                "name": "post-interrupt-check",
+                "path": "post_interrupt_tuned_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ]
+    }
+}

--- a/tuned/skyhook_dir/apply_tuned_profile.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -xe
+set -u
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+TUNED_DIR="/etc/tuned"
+
+# ensure tuned directory exists
+sudo mkdir -p "$TUNED_DIR"
+
+# process all other files as custom profiles
+for file in "$CONFIGMAP_DIR"/*; do
+    [ -f "$file" ] || continue # make sure file exists
+    [ "$(basename "$file")" = "tuned_profile" ] && continue  # skip tuned_profile
+
+    profile_name=$(basename "$file")
+    custom_profile_dir="$TUNED_DIR/$profile_name"
+
+    # Create a directory for the custom profile if it doesn't exist
+    sudo mkdir -p "$custom_profile_dir"
+
+    # Copy the file contents as tuned.conf
+    sudo cp "$file" "$custom_profile_dir/tuned.conf"
+    echo "created custom tuned profile: $profile_name"
+done
+
+# Now apply the main profile
+TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
+if [ -f "$TUNED_PROFILE_FILE" ]; then
+    tuned_profile=$(cat "$TUNED_PROFILE_FILE" | xargs)  # read and trim
+    if tuned-adm list | grep -q "^- $tuned_profile"; then
+        echo "applying tuned profile: $tuned_profile"
+        sudo tuned-adm profile "$tuned_profile"
+    else
+        echo "ERROR: tuned profile '$tuned_profile' not found"
+        exit 1
+    fi
+else
+    echo "WARNING: no tuned_profile file found in $CONFIGMAP_DIR"
+fi

--- a/tuned/skyhook_dir/apply_tuned_profile_check.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile_check.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -x
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+TUNED_DIR="/etc/tuned"
+
+# check tuned service is installed and running
+if ! command -v tuned-adm >/dev/null 2>&1; then
+    echo "ERROR: tuned-adm is not installed"
+    exit 1
+fi
+
+if ! systemctl is-active --quiet tuned; then
+    echo "ERROR: tuned service is not running"
+    exit 1
+fi
+
+# check configmaps directory exists
+if [ ! -d "$CONFIGMAP_DIR" ]; then
+    echo "ERROR: configmaps directory does not exist: $CONFIGMAP_DIR"
+    exit 1
+fi
+
+# verify custom profiles
+for file in "$CONFIGMAP_DIR"/*; do
+    [ -f "$file" ] || continue
+
+    base_file=$(basename "$file")
+    [ "$base_file" = "tuned_profile" ] && continue
+
+    custom_profile_dir="$TUNED_DIR/$base_file"
+    custom_profile_file="$custom_profile_dir/tuned.conf"
+
+    if [ ! -d "$custom_profile_dir" ]; then
+        echo "ERROR: custom tuned profile directory missing: $custom_profile_dir"
+        exit 1
+    fi
+
+    if [ ! -f "$custom_profile_file" ]; then
+        echo "ERROR: tuned configuration file missing: $custom_profile_file"
+        exit 1
+    fi
+
+    echo "verified custom profile: $base_file"
+done
+
+# verify the main profile is active
+TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
+if [ ! -f "$TUNED_PROFILE_FILE" ]; then
+    echo "WARNING: tuned_profile file missing in $CONFIGMAP_DIR"
+else
+    tuned_profile=$(cat "$TUNED_PROFILE_FILE" | xargs)
+    if tuned-adm list | grep -q "^- $tuned_profile"; then
+        active_profile=$(tuned-adm active | awk -F: '{print $2}' | xargs)
+        if [ "$active_profile" != "$tuned_profile" ]; then
+            echo "ERROR: tuned profile '$tuned_profile' is not active (active: $active_profile)"
+            exit 1
+        fi
+    else
+        echo "ERROR: tuned profile '$tuned_profile' not found in tuned-adm list"
+        exit 1
+    fi
+fi
+
+# verify that the profile is applied
+if ! tuned-adm verify; then
+    echo "ERROR: tuned-adm verify failed"
+
+    echo "tuned-adm verify logs:"
+    cat /var/log/tuned/tuned.log
+
+    if [[ "${INTERRUPT}" != "true" ]]; then
+        echo "WARNING: Set the INTERRUPT environment variable to true if you're tunings require an interrupt or else the tunings can't be verified"
+        exit 1
+    fi
+fi 

--- a/tuned/skyhook_dir/install_tuned.sh
+++ b/tuned/skyhook_dir/install_tuned.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xe
+set -u
+
+source /etc/os-release
+case $ID in
+    ubuntu* | debian*)
+        export DEBIAN_FRONTEND=noninteractive
+
+        apt update -y && apt upgrade -y
+        apt install -o DPKG::Lock::Timeout=60 -y tuned
+    ;;
+    centos* | redhat* | amzn*)
+        yum update -y
+        yum install -y tuned
+    ;;
+    fedora*)
+        dnf upgrade -y
+        dnf install -y tuned
+    ;;
+    *)
+        echo "Unsupported Distro: $ID"
+        exit 1
+    ;;
+esac
+
+# enable tuned service
+systemctl enable --now tuned
+systemctl status tuned

--- a/tuned/skyhook_dir/install_tuned_check.sh
+++ b/tuned/skyhook_dir/install_tuned_check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -x
+
+# wait for tuned
+sleep 1
+
+# ensure that tuned is installed
+if ! command -v tuned >/dev/null 2>&1; then
+    echo "ERROR: tuned is not installed."
+    exit 1
+fi
+
+# ensure that tuned-adm is installed
+if ! command -v tuned-adm >/dev/null 2>&1; then
+    echo "ERROR: tuned-adm is not installed."
+    exit 1
+fi
+
+# ensure that the tuned service is started
+if ! systemctl is-active --quiet tuned; then
+    echo "ERROR: tuned isn't running"
+    exit 1
+fi
+
+# ensure that the tuned service is enabled so it
+# starts on system bring up
+if ! systemctl is-enabled --quiet tuned; then
+    echo "ERROR: tuned is not enabled at boot"
+    exit 1
+fi

--- a/tuned/skyhook_dir/post_interrupt_tuned_check.sh
+++ b/tuned/skyhook_dir/post_interrupt_tuned_check.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -x
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+TUNED_DIR="/etc/tuned"
+
+# check tuned service is installed and running
+if ! command -v tuned-adm >/dev/null 2>&1; then
+    echo "ERROR: tuned-adm is not installed"
+    exit 1
+fi
+
+if ! systemctl is-active --quiet tuned; then
+    echo "ERROR: tuned service is not running"
+    exit 1
+fi
+
+# check configmaps directory exists
+if [ ! -d "$CONFIGMAP_DIR" ]; then
+    echo "ERROR: configmaps directory does not exist: $CONFIGMAP_DIR"
+    exit 1
+fi
+
+# verify custom profiles
+for file in "$CONFIGMAP_DIR"/*; do
+    [ -f "$file" ] || continue
+
+    base_file=$(basename "$file")
+    [ "$base_file" = "tuned_profile" ] && continue
+
+    custom_profile_dir="$TUNED_DIR/$base_file"
+    custom_profile_file="$custom_profile_dir/tuned.conf"
+
+    if [ ! -d "$custom_profile_dir" ]; then
+        echo "ERROR: custom tuned profile directory missing: $custom_profile_dir"
+        exit 1
+    fi
+
+    if [ ! -f "$custom_profile_file" ]; then
+        echo "ERROR: tuned configuration file missing: $custom_profile_file"
+        exit 1
+    fi
+
+    echo "verified custom profile: $base_file"
+done
+
+# verify the main profile
+TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
+if [ ! -f "$TUNED_PROFILE_FILE" ]; then
+    echo "WARNING: tuned_profile file missing in $CONFIGMAP_DIR"
+else
+    tuned_profile=$(cat "$TUNED_PROFILE_FILE" | xargs)
+    if tuned-adm list | grep -q "^- $tuned_profile"; then
+        active_profile=$(tuned-adm active | awk -F: '{print $2}' | xargs)
+        if [ "$active_profile" != "$tuned_profile" ]; then
+            echo "ERROR: tuned profile '$tuned_profile' is not active (active: $active_profile)"
+            exit 1
+        fi
+    else
+        echo "ERROR: tuned profile '$tuned_profile' not found in tuned-adm list"
+        exit 1
+    fi
+fi
+
+# verify that the profile is applied
+if ! tuned-adm verify; then
+    echo "ERROR: tuned-adm verify failed"
+
+    echo "tuned-adm verify logs:"
+    cat /var/log/tuned/tuned.log
+
+    exit 1
+fi

--- a/tuned/skyhook_dir/uninstall_tuned.sh
+++ b/tuned/skyhook_dir/uninstall_tuned.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -xe
+set -u
+
+source /etc/os-release
+case $ID in
+    ubuntu* | debian*)
+        export DEBIAN_FRONTEND=noninteractive
+
+        apt remove -y tuned && apt autoremove -y
+    ;;
+    centos* | redhat* | amzn*)
+        yum remove -y tuned
+    ;;
+    fedora*)
+        dnf remove -y tuned
+    ;;
+    *)
+        echo "Unsupported Distro: $ID"
+        exit 1
+    ;;
+esac
+
+# disable and stop tuned service
+if systemctl is-active --quiet tuned; then
+    systemctl disable --now tuned
+    systemctl status tuned
+fi

--- a/tuned/skyhook_dir/uninstall_tuned_check.sh
+++ b/tuned/skyhook_dir/uninstall_tuned_check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -x
+
+# wait for tuned
+sleep 1
+
+# ensure that tuned is uninstalled
+if command -v tuned >/dev/null 2>&1; then
+    echo "ERROR: tuned is still installed."
+    exit 1
+fi
+
+# ensure that tuned-adm is uninstalled
+if command -v tuned-adm >/dev/null 2>&1; then
+    echo "ERROR: tuned-adm is still installed."
+    exit 1
+fi
+
+# ensure that the tuned service is stopped
+if systemctl is-active --quiet tuned; then
+    echo "ERROR: tuned is still running"
+    exit 1
+fi
+
+# ensure that the tuned service is disabled
+if systemctl is-enabled --quiet tuned; then
+    echo "ERROR: tuned is still enabled at boot"
+    exit 1
+fi


### PR DESCRIPTION
# Add Tuned Package for Automated Performance Tuning

This PR introduces a new `tuned` package that provides automated system performance tuning through the tuned daemon across multiple Linux distributions.

## Key Features

- **Multi-distribution support**: Ubuntu/Debian (apt), CentOS/RHEL/Amazon Linux (yum), and Fedora (dnf)
- **Custom profile management**: Deploy custom tuned profiles via configmaps
- **Full lifecycle support**: Install, configure, validate, and uninstall with proper interrupt handling
- **Idempotent operations**: Safe for repeated execution
- **Comprehensive validation**: Built-in checks for installation, configuration, and profile verification

## Other

- Complete lifecycle implementation with 8 modes (apply, config, uninstall, etc.)
- Custom profile deployment from `${SKYHOOK_DIR}/configmaps/`
- Support for both built-in profiles (balanced, powersave, throughput-performance) and custom profiles
- Proper service management with systemd integration

## Documentation

- Comprehensive README with usage examples, troubleshooting, and configuration details
- Updated main project README to include the new package
- Clear documentation of configmap requirements and profile management

## Summary

This package enables declarative performance tuning at scale, allowing administrators to apply consistent tuning profiles across their infrastructure with Skyhook.

### Files Added/Modified

- `tuned/` - New package directory with complete implementation
- `tuned/README.md` - Comprehensive package documentation
- `README.md` - Updated to include tuned package information