### PR TITLE
Fix nvidia-tuned and nvidia-setup for eks-gb200

### DIFF
--- a/nvidia-setup/skyhook_dir/steps/upgrade.sh
+++ b/nvidia-setup/skyhook_dir/steps/upgrade.sh
@@ -18,10 +18,15 @@
 
 set -e
 export DEBIAN_FRONTEND=noninteractive
+# Preserve local /etc/* edits and never prompt on conffile diffs during unattended upgrades.
+APT_OPTS=(
+  -o Dpkg::Options::=--force-confdef
+  -o Dpkg::Options::=--force-confold
+)
 apt-get update
 if [ -z "${SKIP_SYSTEM_OPERATIONS:-}" ]; then
-  apt-get upgrade -y
+  apt-get "${APT_OPTS[@]}" upgrade -y
 else
   echo "Skipping system upgrade for test environment"
 fi
-apt-get install -y curl git wget gpg
+apt-get "${APT_OPTS[@]}" install -y curl git wget gpg

--- a/nvidia-tuned/profiles/os/common/nvidia-gb200-performance/containerd_service.sh
+++ b/nvidia-tuned/profiles/os/common/nvidia-gb200-performance/containerd_service.sh
@@ -23,9 +23,7 @@ set -e
 
 DROPIN_DIR=/etc/systemd/system/containerd.service.d
 DROPIN_FILE=containerd.conf
-EXPECTED_CONTENT='[Service]
-LimitSTACK=67108864
-'
+EXPECTED_LINE='LimitSTACK=67108864'
 
 apply_dropin() {
 	mkdir -p "$DROPIN_DIR"
@@ -51,7 +49,7 @@ verify_dropin() {
 	if [ ! -f "$DROPIN_DIR/$DROPIN_FILE" ]; then
 		$ignore_missing && exit 0 || exit 1
 	fi
-	if [ "$(cat "$DROPIN_DIR/$DROPIN_FILE")" != "$EXPECTED_CONTENT" ]; then
+	if [ "$(grep -c -F -x "$EXPECTED_LINE" "$DROPIN_DIR/$DROPIN_FILE")" -lt 1 ]; then
 		exit 1
 	fi
 	exit 0


### PR DESCRIPTION
# nvidia-tuned
verify containerd drop-in via LimitSTACK line match

The previous verify_dropin compared $(cat ...) — which strips trailing newlines — against an EXPECTED_CONTENT string that included one, so verify always exited non-zero on a correctly-applied drop-in. Switch to 'grep -c -F -x "$EXPECTED_LINE"' so verify just confirms the LimitSTACK line is present, avoiding both the trailing-newline pitfall and any incidental formatting differences in the drop-in file.

# nvidia-setup
Use confdef and confold to mimic unattended upgrade behavior when doing the upgrade.sh part of apply.


## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
