### PR TITLE
fix(general/ci): lowercase image reference for cosign signing

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -162,6 +162,10 @@ runs:
     - name: Sign image (keyless)
       if: inputs.sign_image == 'true'
       shell: bash
+      # The reference goes through env rather than inline ${{ }} expansion so
+      # tag-derived inputs cannot inject shell into the script.
+      env:
+        IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}@${{ steps.push.outputs.digest }}
       run: |
         # Keyless signature via the GitHub Actions OIDC identity, recorded in
         # the public Rekor transparency log. --recursive signs the manifest-list
@@ -171,8 +175,7 @@ runs:
         # OCI repository names must be lowercase; image_name comes from
         # github.repository, which carries the uppercase org (NVIDIA/...), so
         # lowercase the reference before handing it to cosign.
-        ref="${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}@${{ steps.push.outputs.digest }}"
-        cosign sign --yes --recursive "${ref,,}"
+        cosign sign --yes --recursive "${IMAGE_REF,,}"
 
     - name: Save image info
       if: inputs.save_image_info == 'true'

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -168,8 +168,11 @@ runs:
         # digest AND every platform-specific child manifest under it, so a pull
         # by a per-architecture digest still verifies. cosign reuses the docker
         # login performed above to push the .sig back to the registry.
-        cosign sign --yes --recursive \
-          "${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}@${{ steps.push.outputs.digest }}"
+        # OCI repository names must be lowercase; image_name comes from
+        # github.repository, which carries the uppercase org (NVIDIA/...), so
+        # lowercase the reference before handing it to cosign.
+        ref="${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}@${{ steps.push.outputs.digest }}"
+        cosign sign --yes --recursive "${ref,,}"
 
     - name: Save image info
       if: inputs.save_image_info == 'true'

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -46,8 +46,12 @@ jobs:
 
       - name: Extract package name from tag
         id: extract
+        # The tag name goes through env rather than inline ${{ }} expansion so
+        # a crafted tag cannot inject shell into the script.
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          PACKAGE_NAME=$(echo "${{ github.ref_name }}" | cut -f 1 -d /)
+          PACKAGE_NAME="${REF_NAME%%/*}"
           echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
@@ -67,12 +71,18 @@ jobs:
       - name: Get manifest information
         id: manifest
         shell: bash
+        # PACKAGE_NAME derives from the tag name, so it goes through env
+        # rather than inline ${{ }} expansion to avoid shell injection.
+        # REGISTRY and IMAGE_NAME are already exported by the workflow env.
+        env:
+          PACKAGE_NAME: ${{ steps.extract.outputs.package_name }}
+          DIGEST: ${{ steps.build.outputs.image_digest }}
         run: |
           # Lowercase because cosign rejects uppercase repository names and
-          # env.IMAGE_NAME comes from github.repository (NVIDIA/...).
-          IMAGE_NAME="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.extract.outputs.package_name }}"
-          echo "subject-name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
-          echo "digest=${{ steps.build.outputs.image_digest }}" >> $GITHUB_OUTPUT
+          # IMAGE_NAME comes from github.repository (NVIDIA/...).
+          SUBJECT_NAME="${REGISTRY}/${IMAGE_NAME}/${PACKAGE_NAME}"
+          echo "subject-name=${SUBJECT_NAME,,}" >> $GITHUB_OUTPUT
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
       # SLSA build provenance is attested by the build-package action above
       # (generate_attestation: 'true'); no separate attestation is needed here.

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -68,8 +68,10 @@ jobs:
         id: manifest
         shell: bash
         run: |
+          # Lowercase because cosign rejects uppercase repository names and
+          # env.IMAGE_NAME comes from github.repository (NVIDIA/...).
           IMAGE_NAME="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.extract.outputs.package_name }}"
-          echo "subject-name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "subject-name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
           echo "digest=${{ steps.build.outputs.image_digest }}" >> $GITHUB_OUTPUT
 
       # SLSA build provenance is attested by the build-package action above


### PR DESCRIPTION
## Problem

The [nvidia-setup/0.4.0 release run](https://github.com/NVIDIA/nodewright-packages/actions/runs/28615756475/job/84859069041) failed at the keyless signing step added in #82:

```text
Error: signing [ghcr.io/NVIDIA/nodewright-packages/nvidia-setup@sha256:c6168a7d...]:
parsing reference: could not parse reference
```

The sign step builds the cosign reference from `github.repository`, which carries the uppercase org name (`NVIDIA/nodewright-packages`). OCI repository names must be lowercase, so cosign rejects the reference. The build and push succeed because `docker/metadata-action` lowercases image names itself; the raw `IMAGE_NAME` is only used verbatim at signing. This was the first tag push since #82, so it was the first time the path was exercised.

The skipped `Verify image signature and provenance` step has the same latent bug: it builds `IMAGE` from the same uppercase env, so `cosign verify` would fail identically.

## Fix

Lowercase the reference with bash `${var,,}` in both places:

- `build-package` action: lowercase the full ref before `cosign sign`
- `build_container.yaml`: lowercase the `subject-name` output that the verify step consumes

The attestation step needs no change; `actions/attest-build-provenance` normalizes the subject name internally.

## Verification

Simulated the substituted commands locally with the exact values from the failed run:

```text
ghcr.io/nvidia/nodewright-packages/nvidia-setup@sha256:c6168a7dba8d685763536a0a21133bffa7e3240722aaeb7f64da18390c784b56
subject-name=ghcr.io/nvidia/nodewright-packages/nvidia-setup
```

## Follow-up after merge

The release workflow runs from the tagged commit, so re-running the failed job will not pick up this fix. `nvidia-setup/0.4.0` needs to be deleted and re-pushed at a commit containing this change; the rebuild will overwrite the currently unsigned 0.4.0 image and sign it.