### PR TITLE
fix(tuned): version-aware profile directory

### DIFF
--- a/tuned/README.md
+++ b/tuned/README.md
@@ -66,7 +66,7 @@ tuned/
 - **Script**: `apply_tuned_profile.sh`
 - **Purpose**: Deploys custom profiles and applies the specified tuned profile
 - **Process**:
-  1. Creates custom profile directories in `/etc/tuned/`
+  1. Creates custom profile directories in the tuned profiles dir (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
   2. Copies configmap files as `tuned.conf` for each custom profile
   3. Reads the target profile from `tuned_profile` configmap file
   4. Applies the specified profile using `tuned-adm profile`
@@ -151,7 +151,7 @@ The package expects configmaps to be available in `${SKYHOOK_DIR}/configmaps/`:
 - **Custom profile files**: Any files in the configmaps directory (except `tuned_profile` and `*_script` files) will be treated as custom tuned profile configurations
   - File name becomes the profile name
   - File contents become the `tuned.conf` for that profile
-  - Files are deployed to `/etc/tuned/<profile_name>/tuned.conf`
+  - Files are deployed to `<profiles_dir>/<profile_name>/tuned.conf` (`<profiles_dir>` is `/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
 
 - **Script files**: Any files ending with `_script` will be deployed as executable scripts to `/etc/tuned/scripts/`
   - File name pattern: `<name>_script` (e.g., `setup_script`, `my_optimization_script`)
@@ -343,11 +343,11 @@ Use `tuned-adm list` to see all available profiles on your system or go to [tune
 
 2. **Profile not found**
    - List available profiles: `tuned-adm list`
-   - Check custom profile deployment in `/etc/tuned/`
+   - Check custom profile deployment in the tuned profiles dir (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
 
 3. **Permission errors**
    - Ensure scripts run with appropriate privileges
-   - Check `/etc/tuned/` directory permissions
+   - Check tuned profiles dir permissions (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
 
 4. **Verification errors**
    - Check verification: `tuned-adm verify`

--- a/tuned/RELEASE_NOTES.md
+++ b/tuned/RELEASE_NOTES.md
@@ -19,3 +19,9 @@ example is not itself picked up as release notes):
 
     - Notable behavior change worth calling out.
 -->
+
+## 1.3.0
+
+- Custom tuned profiles are now deployed to the directory the installed tuned
+  version reads from. On tuned >= 2.23.0 that is `/etc/tuned/profiles`; on older
+  tuned it remains `/etc/tuned`. No action is required.

--- a/tuned/RELEASE_NOTES.md
+++ b/tuned/RELEASE_NOTES.md
@@ -25,3 +25,7 @@ example is not itself picked up as release notes):
 - Custom tuned profiles are now deployed to the directory the installed tuned
   version reads from. On tuned >= 2.23.0 that is `/etc/tuned/profiles`; on older
   tuned it remains `/etc/tuned`. No action is required.
+- This is driven by newer distributions shipping tuned >= 2.23.0, which reads
+  profiles only from the `profiles/` subdirectory. In particular, Ubuntu 26.04
+  installs tuned 2.25, so profiles written to the old `/etc/tuned/<profile>`
+  location were no longer picked up.

--- a/tuned/config.json
+++ b/tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "tuned",
-    "package_version": "1.0.0",
+    "package_version": "1.3.0",
     "expected_config_files": [],
     "modes": {
         "uninstall": [

--- a/tuned/skyhook_dir/apply_tuned_profile.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tuned/skyhook_dir/apply_tuned_profile.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile.sh
@@ -76,7 +76,7 @@ done
 # Supports multiple space-separated profiles, e.g., "hpc-compute aws"
 TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
 if [ -f "$TUNED_PROFILE_FILE" ]; then
-    tuned_profiles=$(cat "$TUNED_PROFILE_FILE" | xargs)  # read and trim
+    tuned_profiles=$(xargs < "$TUNED_PROFILE_FILE")  # read and trim
     
     # Count the number of profiles
     # shellcheck disable=SC2086

--- a/tuned/skyhook_dir/apply_tuned_profile.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile.sh
@@ -26,7 +26,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utils.sh"
 
 CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
-TUNED_DIR="/etc/tuned"
+# Deploy custom profiles where the installed tuned version reads them.
+resolve_tuned_profiles_dir
+TUNED_DIR="${TUNED_PROFILES_DIR}"
 SCRIPTS_DIR="/etc/tuned/scripts"
 
 # ensure tuned directory exists

--- a/tuned/skyhook_dir/apply_tuned_profile_check.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tuned/skyhook_dir/apply_tuned_profile_check.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile_check.sh
@@ -107,7 +107,7 @@ TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
 if [ ! -f "$TUNED_PROFILE_FILE" ]; then
     echo "WARNING: tuned_profile file missing in $CONFIGMAP_DIR"
 else
-    tuned_profiles=$(cat "$TUNED_PROFILE_FILE" | xargs)
+    tuned_profiles=$(xargs < "$TUNED_PROFILE_FILE")
     
     # Count the number of profiles
     # shellcheck disable=SC2086

--- a/tuned/skyhook_dir/apply_tuned_profile_check.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile_check.sh
@@ -25,7 +25,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utils.sh"
 
 CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
-TUNED_DIR="/etc/tuned"
+# Verify custom profiles where the installed tuned version reads them.
+resolve_tuned_profiles_dir
+TUNED_DIR="${TUNED_PROFILES_DIR}"
 SCRIPTS_DIR="/etc/tuned/scripts"
 
 # check tuned service is installed and running

--- a/tuned/skyhook_dir/post_interrupt_tuned_check.sh
+++ b/tuned/skyhook_dir/post_interrupt_tuned_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tuned/skyhook_dir/post_interrupt_tuned_check.sh
+++ b/tuned/skyhook_dir/post_interrupt_tuned_check.sh
@@ -107,7 +107,7 @@ TUNED_PROFILE_FILE="$CONFIGMAP_DIR/tuned_profile"
 if [ ! -f "$TUNED_PROFILE_FILE" ]; then
     echo "WARNING: tuned_profile file missing in $CONFIGMAP_DIR"
 else
-    tuned_profiles=$(cat "$TUNED_PROFILE_FILE" | xargs)
+    tuned_profiles=$(xargs < "$TUNED_PROFILE_FILE")
     
     # Validate each profile exists
     available_profiles=$(tuned-adm list)

--- a/tuned/skyhook_dir/post_interrupt_tuned_check.sh
+++ b/tuned/skyhook_dir/post_interrupt_tuned_check.sh
@@ -19,8 +19,15 @@
 
 set -x
 
+# Source shared utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils.sh
+source "${SCRIPT_DIR}/utils.sh"
+
 CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
-TUNED_DIR="/etc/tuned"
+# Verify custom profiles where the installed tuned version reads them.
+resolve_tuned_profiles_dir
+TUNED_DIR="${TUNED_PROFILES_DIR}"
 SCRIPTS_DIR="/etc/tuned/scripts"
 
 # check tuned service is installed and running

--- a/tuned/skyhook_dir/utils.sh
+++ b/tuned/skyhook_dir/utils.sh
@@ -91,5 +91,5 @@ resolve_tuned_profiles_dir() {
         TUNED_PROFILES_DIR="/etc/tuned"
     fi
 
-    echo "tuned $tuned_version: deploying profiles to $TUNED_PROFILES_DIR"
+    echo "tuned $tuned_version: profiles dir is $TUNED_PROFILES_DIR"
 }

--- a/tuned/skyhook_dir/utils.sh
+++ b/tuned/skyhook_dir/utils.sh
@@ -85,7 +85,12 @@ resolve_tuned_profiles_dir() {
     major="$(echo "$tuned_version" | cut -d. -f1)"
     minor="$(echo "$tuned_version" | cut -d. -f2)"
 
-    if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 23 ]; }; then
+    if ! [[ "$major" =~ ^[0-9]+$ ]] || ! [[ "$minor" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: Could not parse tuned version: $tuned_version"
+        exit 1
+    fi
+
+    if [[ "$major" -gt 2 ]] || { [[ "$major" -eq 2 ]] && [[ "$minor" -ge 23 ]]; }; then
         TUNED_PROFILES_DIR="/etc/tuned/profiles"
     else
         TUNED_PROFILES_DIR="/etc/tuned"

--- a/tuned/skyhook_dir/utils.sh
+++ b/tuned/skyhook_dir/utils.sh
@@ -32,7 +32,7 @@ check_tuned_version_for_multiple_profiles() {
     
     # Get tuned version (format: "tuned 2.21.0")
     local tuned_version
-    tuned_version=$(tuned --version 2>/dev/null | awk '{print $2}')
+    tuned_version="$(get_tuned_version)"
     
     if [ -z "$tuned_version" ]; then
         echo "ERROR: Could not determine tuned version"
@@ -59,4 +59,37 @@ check_tuned_version_for_multiple_profiles() {
     fi
     
     echo "tuned version $tuned_version supports multiple profiles"
+}
+
+# Get the installed tuned version string (e.g. "2.23.0").
+# Echoes an empty string if tuned is not installed or the version cannot be parsed.
+get_tuned_version() {
+    tuned --version 2>/dev/null | awk '{print $2}'
+}
+
+# Set TUNED_PROFILES_DIR to the single directory all tuned profiles should be
+# deployed to, based on the installed tuned version. tuned >= 2.23.0 reads
+# profiles only from the profiles/ subdirectory (/etc/tuned/profiles); older
+# tuned reads them directly from /etc/tuned. We deploy everything to this one
+# user directory and write nothing to /usr/lib/tuned (tuned resolves include=
+# targets across all profile_dirs, and the user dir takes precedence).
+# Exits 1 if the tuned version cannot be determined.
+resolve_tuned_profiles_dir() {
+    local tuned_version major minor
+    tuned_version="$(get_tuned_version)"
+    if [ -z "$tuned_version" ]; then
+        echo "ERROR: Could not determine tuned version"
+        exit 1
+    fi
+
+    major="$(echo "$tuned_version" | cut -d. -f1)"
+    minor="$(echo "$tuned_version" | cut -d. -f2)"
+
+    if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 23 ]; }; then
+        TUNED_PROFILES_DIR="/etc/tuned/profiles"
+    else
+        TUNED_PROFILES_DIR="/etc/tuned"
+    fi
+
+    echo "tuned $tuned_version: deploying profiles to $TUNED_PROFILES_DIR"
 }


### PR DESCRIPTION
## Summary

The `tuned` package now deploys and verifies custom tuned profiles in the directory the installed tuned version actually reads from:

- tuned >= 2.23.0: `/etc/tuned/profiles`
- older tuned: `/etc/tuned`

Before this change, profiles were written only to the legacy `/etc/tuned/<profile>` location, which tuned >= 2.23.0 no longer searches by default (the default `profile_dirs` became the `profiles/` subdirectories in tuned 2.23.0). On distros shipping tuned >= 2.23.0 (RHEL 9.5+, newer Ubuntu/Debian) `tuned-adm profile` could not find the profiles.

## Changes

- `skyhook_dir/utils.sh`: new `get_tuned_version` and `resolve_tuned_profiles_dir` helpers (the latter sets `TUNED_PROFILES_DIR` from the installed version); refactored `check_tuned_version_for_multiple_profiles` to reuse `get_tuned_version` (its 2.24 multi-profile boundary is unchanged).
- `skyhook_dir/apply_tuned_profile.sh`, `apply_tuned_profile_check.sh`, `post_interrupt_tuned_check.sh`: deploy and verify custom profiles under the resolved directory. `/etc/tuned/scripts` (the `_script` deploy dir) is unchanged.
- `config.json`: `package_version` 1.0.0 -> 1.3.0 (minor bump; the release aggregates unreleased `feat(tuned)` commits since `tuned/1.2.0`).
- `RELEASE_NOTES.md`, `README.md`: document the version-aware directory.

## Notes

- This is Part 1 of 2. Part 2 updates the `nvidia-tuned` package (which inherits this `utils.sh` from the `tuned` base image) and will follow after `tuned/1.3.0` is tagged and its image is published.
- After merge, tag `tuned/1.3.0` to build and publish the image.
- The Docker-based integration suite and `make validate-standalone` were not run locally; `shellcheck` (only pre-existing SC2002 style findings) and `make license-check` pass.
