### PR TITLE
fix(nvidia-tuned): version-aware profile directory on tuned 1.3.1 base

### DIFF
--- a/nvidia-tuned/Dockerfile
+++ b/nvidia-tuned/Dockerfile
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG TUNED_VERSION=1.2.0
+ARG TUNED_VERSION=1.3.1
 
-FROM ghcr.io/nvidia/skyhook-packages/tuned:${TUNED_VERSION}
+FROM ghcr.io/nvidia/nodewright-packages/tuned:${TUNED_VERSION}
 
 COPY ./ /skyhook-package
 

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -6,7 +6,7 @@ A NodeWright package that extends the base `tuned` package with NVIDIA-specific 
 
 This package inherits from the base `tuned` package and adds pre-configured tuned profiles optimized for NVIDIA hardware. The profiles are organized by:
 
-- **Common base profiles**: Foundational settings deployed to `/usr/lib/tuned/`
+- **Common base profiles**: Foundational settings deployed to the tuned profiles dir (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
 - **OS-specific workload profiles**: Profiles that may vary by OS version
 - **Service profiles**: Service-specific settings (eks, GCP, etc.)
 
@@ -36,7 +36,7 @@ This package requires **tuned >= 2.19**. The following operating systems are sup
 
 ```
 profiles/
-├── common/                  # Base profiles → /usr/lib/tuned/
+├── common/                  # Base profiles → tuned profiles dir
 │   ├── nvidia-base/
 │   └── nvidia-acs-disable/
 ├── os/
@@ -78,9 +78,9 @@ Note: Profiles are stored in `profiles/` (not `root_dir/`) to avoid polluting th
 1. **Prepare stage**: `prepare_nvidia_profiles.sh` runs:
    - Reads `intent` and `accelerator` from the configmap
    - Constructs the profile name as `nvidia-{accelerator}-{intent}`
-   - Deploys common base profiles to `/usr/lib/tuned/`
+   - Deploys common base profiles to the resolved tuned profiles dir
    - Detects OS from `/etc/os-release`
-   - Copies the appropriate OS-specific workload profiles to `/etc/tuned/`
+   - Copies the appropriate OS-specific workload profiles to the resolved tuned profiles dir (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
    - If a `service` is specified, creates service profile with dynamic `include=` pointing to the workload profile
 
 2. **Config stage**: The inherited `tuned` package applies the configured profile

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -19,3 +19,11 @@ example is not itself picked up as release notes):
 
     - Notable behavior change worth calling out.
 -->
+
+## 0.3.1
+
+- NVIDIA tuned profiles are now deployed to the directory the installed tuned
+  version reads from (`/etc/tuned/profiles` on tuned >= 2.23.0, else `/etc/tuned`),
+  fixing profiles being invisible to tuned on distros shipping tuned >= 2.23.0.
+  All profiles, including the common base profiles, now live in that one
+  directory; nothing is written to `/usr/lib/tuned`. No action is required.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.3.0",
+    "package_version": "0.3.1",
     "expected_config_files": ["accelerator"],
     "modes": {
         "uninstall": [

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
@@ -20,17 +20,20 @@
 # 1. Reading intent, accelerator, and service from configmap
 # 2. Constructing the workload profile name as nvidia-{accelerator}-{intent}
 # 3. Final profile name: {service}-{accelerator}-{intent} when service is set, else workload profile name
-# 4. Copying common base profiles to /usr/lib/tuned/
+# 4. Copying common base profiles to the resolved profiles directory
 # 5. Selecting the appropriate OS-specific workload profiles
 # 6. Setting up the service profile with dynamic include
 
 set -xe
 set -u
 
+# Source shared utilities (inherited from the tuned base image)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils.sh
+source "${SCRIPT_DIR}/utils.sh"
+
 CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
 PROFILES_DIR="${SKYHOOK_DIR}/profiles"
-TUNED_SYSTEM_DIR="/usr/lib/tuned"
-TUNED_USER_DIR="/etc/tuned"
 
 # Read configmap fields
 INTENT_FILE="$CONFIGMAP_DIR/intent"
@@ -65,16 +68,16 @@ build_profile_name() {
     echo "nvidia-${accelerator}-${intent}"
 }
 
-# Copy common base profiles to /usr/lib/tuned/
+# Copy common base profiles to the resolved tuned profiles dir
 deploy_common_profiles() {
-    echo "Deploying common profiles to $TUNED_SYSTEM_DIR..."
+    echo "Deploying common profiles to $TUNED_PROFILES_DIR..."
 
     if [ -d "$PROFILES_DIR/common" ]; then
         for profile_dir in "$PROFILES_DIR/common"/*/; do
             [ -d "$profile_dir" ] || continue
             profile_name=$(basename "$profile_dir")
-            rm -rf "$TUNED_SYSTEM_DIR/$profile_name"
-            cp -rL "$profile_dir" "$TUNED_SYSTEM_DIR/$profile_name"
+            rm -rf "${TUNED_PROFILES_DIR:?}/$profile_name"
+            cp -rL "$profile_dir" "$TUNED_PROFILES_DIR/$profile_name"
             echo "Deployed common profile: $profile_name"
         done
     else
@@ -84,9 +87,15 @@ deploy_common_profiles() {
 
 # Deploy ALL OS-specific workload profiles
 deploy_os_profiles() {
-    echo "Deploying OS profiles to $TUNED_USER_DIR..."
+    echo "Deploying OS profiles to $TUNED_PROFILES_DIR..."
 
-    mkdir -p "$TUNED_USER_DIR"
+    mkdir -p "$TUNED_PROFILES_DIR"
+
+    # Track what this function deploys. Since all profiles now share one
+    # directory (common base profiles are deployed here first), checking the
+    # directory's overall contents no longer tells us whether OS profiles were
+    # found, so track it explicitly instead.
+    local deployed_any=false
 
     # Always deploy from os/common first (provides all profiles)
     if [ -d "$PROFILES_DIR/os/common" ]; then
@@ -94,8 +103,9 @@ deploy_os_profiles() {
         for profile_dir in "$PROFILES_DIR/os/common"/*/; do
             [ -d "$profile_dir" ] || continue
             profile_name=$(basename "$profile_dir")
-            rm -rf "$TUNED_USER_DIR/$profile_name"
-            cp -rL "$profile_dir" "$TUNED_USER_DIR/$profile_name"
+            rm -rf "${TUNED_PROFILES_DIR:?}/$profile_name"
+            cp -rL "$profile_dir" "$TUNED_PROFILES_DIR/$profile_name"
+            deployed_any=true
             echo "Deployed common profile: $profile_name"
         done
     else
@@ -108,14 +118,15 @@ deploy_os_profiles() {
         for profile_dir in "$PROFILES_DIR/os/$OS_ID/$VERSION"/*/; do
             [ -d "$profile_dir" ] || continue
             profile_name=$(basename "$profile_dir")
-            rm -rf "$TUNED_USER_DIR/$profile_name"
-            cp -rL "$profile_dir" "$TUNED_USER_DIR/$profile_name"
+            rm -rf "${TUNED_PROFILES_DIR:?}/$profile_name"
+            cp -rL "$profile_dir" "$TUNED_PROFILES_DIR/$profile_name"
+            deployed_any=true
             echo "Deployed OS-specific profile: $profile_name"
         done
     fi
 
-    # Verify we have at least some profiles
-    if [ ! -d "$TUNED_USER_DIR" ] || [ -z "$(ls -A "$TUNED_USER_DIR" 2>/dev/null)" ]; then
+    # Verify this function actually deployed at least one OS profile
+    if [ "$deployed_any" = false ]; then
         echo "ERROR: No OS profiles found in os/$OS_ID/$VERSION/ or os/common/"
         exit 1
     fi
@@ -125,11 +136,11 @@ deploy_os_profiles() {
 validate_profile() {
     local profile=$1
 
-    if [ ! -d "$TUNED_USER_DIR/$profile" ]; then
-        echo "ERROR: Constructed profile '$profile' not found in $TUNED_USER_DIR"
+    if [ ! -d "$TUNED_PROFILES_DIR/$profile" ]; then
+        echo "ERROR: Constructed profile '$profile' not found in $TUNED_PROFILES_DIR"
         echo "  intent=$INTENT, accelerator=$ACCELERATOR -> profile=$profile"
         echo "Available profiles:"
-        ls -1 "$TUNED_USER_DIR" 2>/dev/null || echo "  (none)"
+        ls -1 "$TUNED_PROFILES_DIR" 2>/dev/null || echo "  (none)"
         exit 1
     fi
 
@@ -165,8 +176,8 @@ deploy_service_profile() {
     if [ -f "$service_specific_profile" ]; then
         echo "Found service-specific profile: $service_specific_profile"
         # Deploy the service-specific profile to /etc/tuned/
-        mkdir -p "$TUNED_USER_DIR/$profile"
-        cp "$service_specific_profile" "$TUNED_USER_DIR/$profile/tuned.conf"
+        mkdir -p "$TUNED_PROFILES_DIR/$profile"
+        cp "$service_specific_profile" "$TUNED_PROFILES_DIR/$profile/tuned.conf"
         echo "Deployed service-specific profile: $profile"
         # Use the service-specific profile in the include
         local profile_to_include="$profile"
@@ -176,8 +187,8 @@ deploy_service_profile() {
     fi
 
     # Create service profile directory (final profile name = {service}-{accelerator}-{intent}); remove first so changed content is applied
-    rm -rf "$TUNED_USER_DIR/$final_profile_name"
-    mkdir -p "$TUNED_USER_DIR/$final_profile_name"
+    rm -rf "${TUNED_PROFILES_DIR:?}/$final_profile_name"
+    mkdir -p "$TUNED_PROFILES_DIR/$final_profile_name"
 
     # Copy shared helper scripts from profiles/service/common/ into the final profile dir.
     # Each service's script.sh sources these helpers from its own profile dir ($SCRIPT_DIR).
@@ -187,8 +198,8 @@ deploy_service_profile() {
             [ -f "$helper" ] || continue
             local helper_name
             helper_name=$(basename "$helper")
-            cp "$helper" "$TUNED_USER_DIR/$final_profile_name/$helper_name"
-            chmod +x "$TUNED_USER_DIR/$final_profile_name/$helper_name"
+            cp "$helper" "$TUNED_PROFILES_DIR/$final_profile_name/$helper_name"
+            chmod +x "$TUNED_PROFILES_DIR/$final_profile_name/$helper_name"
             echo "Copied shared helper: $helper_name"
         done
     fi
@@ -197,7 +208,7 @@ deploy_service_profile() {
     local template="$service_dir/tuned.conf.template"
     if [ -f "$template" ]; then
         # Insert include= line after [main]
-        sed "s/^\[main\]/[main]\ninclude=$profile_to_include/" "$template" | tee "$TUNED_USER_DIR/$final_profile_name/tuned.conf" > /dev/null
+        sed "s/^\[main\]/[main]\ninclude=$profile_to_include/" "$template" | tee "$TUNED_PROFILES_DIR/$final_profile_name/tuned.conf" > /dev/null
         echo "Created service profile: $final_profile_name with include=$profile_to_include"
     else
         echo "ERROR: Service template not found: $template"
@@ -210,8 +221,8 @@ deploy_service_profile() {
         filename=$(basename "$file")
         [ "$filename" = "tuned.conf.template" ] && continue
         [[ "$filename" == *.conf ]] && continue  # Skip .conf files (they're service-specific profiles)
-        cp "$file" "$TUNED_USER_DIR/$final_profile_name/$filename"
-        chmod +x "$TUNED_USER_DIR/$final_profile_name/$filename" 2>/dev/null || true
+        cp "$file" "$TUNED_PROFILES_DIR/$final_profile_name/$filename"
+        chmod +x "$TUNED_PROFILES_DIR/$final_profile_name/$filename" 2>/dev/null || true
         echo "Copied service file: $filename"
     done
 }
@@ -244,7 +255,7 @@ set_reapply_sysctl_off() {
 main() {
     # Read intent from configmap (defaults to performance)
     if [ -f "$INTENT_FILE" ]; then
-        INTENT=$(cat "$INTENT_FILE" | xargs)
+        INTENT=$(xargs < "$INTENT_FILE")
     fi
     if [ -z "${INTENT:-}" ]; then
         INTENT="performance"
@@ -256,12 +267,17 @@ main() {
         echo "ERROR: accelerator configmap not found at $ACCELERATOR_FILE"
         exit 1
     fi
-    ACCELERATOR=$(cat "$ACCELERATOR_FILE" | xargs)
+    ACCELERATOR=$(xargs < "$ACCELERATOR_FILE")
 
     # Detect OS
     detect_os
 
-    # Deploy common base profiles to /usr/lib/tuned/
+    # Resolve the single profiles directory for the installed tuned version
+    # and ensure it exists before deploying anything into it.
+    resolve_tuned_profiles_dir
+    mkdir -p "${TUNED_PROFILES_DIR}"
+
+    # Deploy common base profiles
     deploy_common_profiles
 
     # Deploy ALL OS-specific profiles to /etc/tuned/
@@ -287,7 +303,7 @@ main() {
 
     # Check if service is specified (optional)
     if [ -f "$SERVICE_FILE" ]; then
-        SERVICE=$(cat "$SERVICE_FILE" | xargs)
+        SERVICE=$(xargs < "$SERVICE_FILE")
     fi
     if [ -n "${SERVICE:-}" ]; then
         if [ "$SERVICE" = "common" ]; then

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles_check.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles_check.sh
@@ -20,10 +20,13 @@
 
 set -x
 
+# Source shared utilities (inherited from the tuned base image)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils.sh
+source "${SCRIPT_DIR}/utils.sh"
+
 CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
 PROFILES_DIR="${SKYHOOK_DIR}/profiles"
-TUNED_SYSTEM_DIR="/usr/lib/tuned"
-TUNED_USER_DIR="/etc/tuned"
 
 # Read configmap fields
 INTENT_FILE="$CONFIGMAP_DIR/intent"
@@ -52,19 +55,19 @@ build_final_profile_name() {
 
 # Verify common profiles are deployed
 verify_common_profiles() {
-    echo "Verifying common profiles in $TUNED_SYSTEM_DIR..."
+    echo "Verifying common profiles in $TUNED_PROFILES_DIR..."
 
     if [ -d "$PROFILES_DIR/common" ]; then
         for profile_dir in "$PROFILES_DIR/common"/*/; do
             [ -d "$profile_dir" ] || continue
             profile_name=$(basename "$profile_dir")
 
-            if [ ! -d "$TUNED_SYSTEM_DIR/$profile_name" ]; then
-                echo "ERROR: Common profile missing: $TUNED_SYSTEM_DIR/$profile_name"
+            if [ ! -d "$TUNED_PROFILES_DIR/$profile_name" ]; then
+                echo "ERROR: Common profile missing: $TUNED_PROFILES_DIR/$profile_name"
                 exit 1
             fi
 
-            if [ ! -f "$TUNED_SYSTEM_DIR/$profile_name/tuned.conf" ]; then
+            if [ ! -f "$TUNED_PROFILES_DIR/$profile_name/tuned.conf" ]; then
                 echo "ERROR: tuned.conf missing for common profile: $profile_name"
                 exit 1
             fi
@@ -76,7 +79,7 @@ verify_common_profiles() {
 
 # Verify ALL OS profiles are deployed
 verify_os_profiles() {
-    echo "Verifying OS profiles in $TUNED_USER_DIR..."
+    echo "Verifying OS profiles in $TUNED_PROFILES_DIR..."
 
     # We need to check that profiles were deployed from either OS-specific or common
     # Read OS info to determine expected source
@@ -105,12 +108,12 @@ verify_os_profiles() {
             local profile_name
             profile_name=$(basename "$profile_dir")
 
-            if [ ! -d "$TUNED_USER_DIR/$profile_name" ]; then
-                echo "ERROR: OS profile directory missing: $TUNED_USER_DIR/$profile_name"
+            if [ ! -d "$TUNED_PROFILES_DIR/$profile_name" ]; then
+                echo "ERROR: OS profile directory missing: $TUNED_PROFILES_DIR/$profile_name"
                 exit 1
             fi
 
-            if [ ! -f "$TUNED_USER_DIR/$profile_name/tuned.conf" ]; then
+            if [ ! -f "$TUNED_PROFILES_DIR/$profile_name/tuned.conf" ]; then
                 echo "ERROR: tuned.conf missing for OS profile: $profile_name"
                 exit 1
             fi
@@ -124,12 +127,12 @@ verify_os_profiles() {
 verify_constructed_profile() {
     local profile=$1
 
-    if [ ! -d "$TUNED_USER_DIR/$profile" ]; then
-        echo "ERROR: Constructed profile directory missing: $TUNED_USER_DIR/$profile"
+    if [ ! -d "$TUNED_PROFILES_DIR/$profile" ]; then
+        echo "ERROR: Constructed profile directory missing: $TUNED_PROFILES_DIR/$profile"
         exit 1
     fi
 
-    if [ ! -f "$TUNED_USER_DIR/$profile/tuned.conf" ]; then
+    if [ ! -f "$TUNED_PROFILES_DIR/$profile/tuned.conf" ]; then
         echo "ERROR: tuned.conf missing for constructed profile: $profile"
         exit 1
     fi
@@ -142,12 +145,12 @@ verify_service_profile() {
     local final_profile_name=$1
     local expected_workload_profile=$2
 
-    if [ ! -d "$TUNED_USER_DIR/$final_profile_name" ]; then
-        echo "ERROR: Service profile directory missing: $TUNED_USER_DIR/$final_profile_name"
+    if [ ! -d "$TUNED_PROFILES_DIR/$final_profile_name" ]; then
+        echo "ERROR: Service profile directory missing: $TUNED_PROFILES_DIR/$final_profile_name"
         exit 1
     fi
 
-    local service_conf="$TUNED_USER_DIR/$final_profile_name/tuned.conf"
+    local service_conf="$TUNED_PROFILES_DIR/$final_profile_name/tuned.conf"
     if [ ! -f "$service_conf" ]; then
         echo "ERROR: tuned.conf missing for service profile: $final_profile_name"
         exit 1
@@ -174,7 +177,7 @@ verify_tuned_profile_file() {
     fi
 
     local actual_profile
-    actual_profile=$(cat "$TUNED_PROFILE_FILE" | xargs)
+    actual_profile=$(xargs < "$TUNED_PROFILE_FILE")
 
     if [ "$actual_profile" != "$expected_profile" ]; then
         echo "ERROR: tuned_profile mismatch. Expected: $expected_profile, Got: $actual_profile"
@@ -185,9 +188,12 @@ verify_tuned_profile_file() {
 }
 
 main() {
+    # Resolve the single profiles directory for the installed tuned version.
+    resolve_tuned_profiles_dir
+
     # Read intent from configmap (defaults to performance)
     if [ -f "$INTENT_FILE" ]; then
-        INTENT=$(cat "$INTENT_FILE" | xargs)
+        INTENT=$(xargs < "$INTENT_FILE")
     fi
     if [ -z "${INTENT:-}" ]; then
         INTENT="performance"
@@ -199,12 +205,12 @@ main() {
         echo "ERROR: accelerator configmap not found at $ACCELERATOR_FILE"
         exit 1
     fi
-    ACCELERATOR=$(cat "$ACCELERATOR_FILE" | xargs)
+    ACCELERATOR=$(xargs < "$ACCELERATOR_FILE")
 
-    # Verify common profiles are deployed to /usr/lib/tuned/
+    # Verify common profiles are deployed
     verify_common_profiles
 
-    # Verify ALL OS profiles are deployed to /etc/tuned/
+    # Verify ALL OS profiles are deployed
     verify_os_profiles
 
     # When accelerator=generic, expect nvidia-generic
@@ -226,7 +232,7 @@ main() {
 
     # Check if service is specified
     if [ -f "$SERVICE_FILE" ]; then
-        SERVICE=$(cat "$SERVICE_FILE" | xargs)
+        SERVICE=$(xargs < "$SERVICE_FILE")
     fi
     if [ -n "${SERVICE:-}" ]; then
         FINAL_PROFILE=$(build_final_profile_name "$SERVICE" "$ACCELERATOR" "$INTENT")

--- a/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
+++ b/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
@@ -32,11 +32,21 @@ Tests verify:
 import pytest
 import re
 
+from pathlib import Path
+
 from tests.helpers.assertions import (
     assert_exit_code,
     assert_output_contains,
 )
 from tests.helpers.docker_test import DockerTestRunner
+
+
+# The prepare scripts source utils.sh, which in production comes from the parent
+# tuned image. The test harness copies only the on-disk nvidia-tuned/ dir into a
+# raw base image, so inject the parent utils.sh explicitly.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+UTILS_SRC = _REPO_ROOT / "tuned" / "skyhook_dir" / "utils.sh"
+UTILS_DEST = "skyhook_dir/utils.sh"
 
 
 def install_tuned_in_container(runner: DockerTestRunner, base_image: str):
@@ -81,6 +91,18 @@ def _matches_any(text: str, *patterns: str) -> bool:
     return any(pattern in text for pattern in patterns)
 
 
+def _get_tuned_major_minor(runner: DockerTestRunner) -> tuple[int, int]:
+    """Parse the container's installed tuned version into (major, minor)."""
+    if runner.container is None:
+        raise RuntimeError("Container not initialized. Call install_tuned_in_container first.")
+    result = runner.container.exec_run(["tuned", "--version"], workdir="/")
+    assert_exit_code(result, 0)
+    output = result.output.decode("utf-8", errors="replace")
+    m = re.search(r"tuned\s+(\d+)\.(\d+)", output)
+    assert m is not None, f"Could not parse tuned version from: {output}"
+    return int(m.group(1)), int(m.group(2))
+
+
 def verify_tuned_version(runner: DockerTestRunner, base_image: str):
     """Verify tuned version meets OS-specific requirement."""
     # Determine required version based on OS
@@ -97,27 +119,22 @@ def verify_tuned_version(runner: DockerTestRunner, base_image: str):
             # Default to 2.19 for unknown OS
             required_major, required_minor = (2, 19)
     
-    # Ensure container is initialized
-    if runner.container is None:
-        raise RuntimeError("Container not initialized. Call install_tuned_in_container first.")
-    
-    result = runner.container.exec_run(
-        ["tuned", "--version"],
-        workdir="/"
-    )
-    
-    assert_exit_code(result, 0)
-    output = result.output.decode('utf-8', errors='replace')
-    
-    # Extract version number (format: "tuned 2.20.0")
-    version_match = re.search(r'tuned\s+(\d+)\.(\d+)', output)
-    assert version_match is not None, f"Could not parse tuned version from: {output}"
-    
-    major = int(version_match.group(1))
-    minor = int(version_match.group(2))
-    
+    major, minor = _get_tuned_major_minor(runner)
+
     assert major > required_major or (major == required_major and minor >= required_minor), \
         f"tuned version {major}.{minor} is less than required {required_major}.{required_minor} for {base_image}"
+
+
+def expected_profiles_dir(runner: DockerTestRunner) -> str:
+    """Return the dir tuned reads profiles from, based on the container's version.
+
+    tuned >= 2.23.0 -> /etc/tuned/profiles ; older -> /etc/tuned.
+    Mirrors resolve_tuned_profiles_dir in tuned/skyhook_dir/utils.sh.
+    """
+    major, minor = _get_tuned_major_minor(runner)
+    if major > 2 or (major == 2 and minor >= 23):
+        return "/etc/tuned/profiles"
+    return "/etc/tuned"
 
 
 def create_container_for_testing(runner: DockerTestRunner, configmaps: dict):
@@ -134,7 +151,13 @@ def create_container_for_testing(runner: DockerTestRunner, configmaps: dict):
     
     # Copy entire package directory structure
     shutil.copytree(runner._package_path, skyhook_package_dir, dirs_exist_ok=True)
-    
+
+    # Inject the parent tuned utils.sh (sourced by the prepare scripts).
+    utils_dest = skyhook_package_dir / "skyhook_dir" / "utils.sh"
+    utils_dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(UTILS_SRC, utils_dest)
+    utils_dest.chmod(0o755)
+
     # Create configmaps directory and write configmaps
     configmaps_dir = skyhook_package_dir / "configmaps"
     configmaps_dir.mkdir(parents=True, exist_ok=True)
@@ -268,10 +291,11 @@ def test_prepare_nvidia_profiles_no_service(base_image, accelerator, intent):
         assert expected_profile in tuned_profile_content, \
             f"Expected profile {expected_profile} not found in tuned_profile file"
         
-        # Verify profile directory exists in /etc/tuned
-        profile_exists = runner.file_exists(f"/etc/tuned/{expected_profile}/tuned.conf")
+        # Verify profile directory exists in the version-resolved profiles dir
+        profiles_dir = expected_profiles_dir(runner)
+        profile_exists = runner.file_exists(f"{profiles_dir}/{expected_profile}/tuned.conf")
         assert profile_exists, \
-            f"Profile {expected_profile} was not deployed to /etc/tuned/"
+            f"Profile {expected_profile} was not deployed to {profiles_dir}/"
         
     finally:
         runner.cleanup()
@@ -294,7 +318,8 @@ def test_prepare_nvidia_profiles_with_eks_service(base_image, accelerator, inten
             runner.run_script(
                 script="prepare_nvidia_profiles.sh",
                 configmaps=configmaps,
-                skip_system_operations=True
+                skip_system_operations=True,
+                extra_files=[(str(UTILS_SRC), UTILS_DEST)],
             )
         except Exception:
             # Script may fail, but container should be created
@@ -320,12 +345,13 @@ def test_prepare_nvidia_profiles_with_eks_service(base_image, accelerator, inten
         assert_output_contains(result.stdout, f"Final profile name: {expected_final_profile}")
         
         # Verify service profile directory exists (final name = eks-{accelerator}-{intent})
-        service_profile_exists = runner.file_exists(f"/etc/tuned/{expected_final_profile}/tuned.conf")
+        profiles_dir = expected_profiles_dir(runner)
+        service_profile_exists = runner.file_exists(f"{profiles_dir}/{expected_final_profile}/tuned.conf")
         assert service_profile_exists, f"EKS service profile {expected_final_profile} was not deployed"
-        
+
         # Verify service profile includes the workload profile
         service_profile_content = runner.get_file_contents(
-            f"/etc/tuned/{expected_final_profile}/tuned.conf"
+            f"{profiles_dir}/{expected_final_profile}/tuned.conf"
         )
         assert f"include={expected_workload_profile}" in service_profile_content, \
             f"EKS profile does not include {expected_workload_profile}"
@@ -339,12 +365,12 @@ def test_prepare_nvidia_profiles_with_eks_service(base_image, accelerator, inten
         
         # For EKS, verify bootloader script exists in final profile dir
         bootloader_script_exists = runner.file_exists(
-            f"/etc/tuned/{expected_final_profile}/bootloader.sh"
+            f"{profiles_dir}/{expected_final_profile}/bootloader.sh"
         )
         assert bootloader_script_exists, "EKS bootloader.sh script was not deployed"
-        
+
         # Verify script.sh exists in final profile dir
-        script_exists = runner.file_exists(f"/etc/tuned/{expected_final_profile}/script.sh")
+        script_exists = runner.file_exists(f"{profiles_dir}/{expected_final_profile}/script.sh")
         assert script_exists, "EKS script.sh was not deployed"
         
     finally:
@@ -380,12 +406,13 @@ def test_prepare_nvidia_profiles_with_aks_service(base_image, intent):
         assert_output_contains(result.stdout, f"Final profile name: {expected_final_profile}")
 
         # Final profile directory exists with tuned.conf
-        assert runner.file_exists(f"/etc/tuned/{expected_final_profile}/tuned.conf"), \
+        profiles_dir = expected_profiles_dir(runner)
+        assert runner.file_exists(f"{profiles_dir}/{expected_final_profile}/tuned.conf"), \
             f"AKS service profile {expected_final_profile} was not deployed"
 
         # tuned.conf includes the workload profile
         service_profile_content = runner.get_file_contents(
-            f"/etc/tuned/{expected_final_profile}/tuned.conf"
+            f"{profiles_dir}/{expected_final_profile}/tuned.conf"
         )
         assert f"include={expected_workload_profile}" in service_profile_content, \
             f"AKS profile does not include {expected_workload_profile}"
@@ -399,7 +426,7 @@ def test_prepare_nvidia_profiles_with_aks_service(base_image, intent):
 
         # Per-service script plus shared helpers are all present and executable
         for helper in ("script.sh", "mac-address-policy.sh", "bootloader.sh"):
-            path = f"/etc/tuned/{expected_final_profile}/{helper}"
+            path = f"{profiles_dir}/{expected_final_profile}/{helper}"
             assert runner.file_exists(path), f"{helper} was not deployed to {path}"
 
     finally:
@@ -446,9 +473,10 @@ def test_prepare_nvidia_profiles_eks_grub_config(base_image):
         
         # Final profile name = eks-h100-inference for this test's configmaps
         final_profile = "eks-h100-inference"
+        profiles_dir = expected_profiles_dir(runner)
         # Run the EKS bootloader script (skip update-grub if it fails)
         bootloader_result = runner.container.exec_run(
-            ["bash", "-c", f"/etc/tuned/{final_profile}/bootloader.sh || true"],
+            ["bash", "-c", f"{profiles_dir}/{final_profile}/bootloader.sh || true"],
             workdir="/"
         )
         
@@ -543,10 +571,11 @@ def test_prepare_nvidia_profiles_generic_accelerator(base_image):
         assert "nvidia-generic" in tuned_profile_content, \
             "Expected nvidia-generic in tuned_profile file"
         
-        # Verify nvidia-generic profile directory exists in /etc/tuned
-        profile_exists = runner.file_exists("/etc/tuned/nvidia-generic/tuned.conf")
+        # Verify nvidia-generic profile directory exists in the version-resolved dir
+        profiles_dir = expected_profiles_dir(runner)
+        profile_exists = runner.file_exists(f"{profiles_dir}/nvidia-generic/tuned.conf")
         assert profile_exists, \
-            "nvidia-generic profile was not deployed to /etc/tuned/"
+            f"nvidia-generic profile was not deployed to {profiles_dir}/"
         
     finally:
         runner.cleanup()
@@ -605,7 +634,8 @@ def test_prepare_nvidia_profiles_generic_ignores_service(base_image):
             f"Expected nvidia-generic (no service wrapping), got: {tuned_profile_content!r}"
         
         # Service profile directory should NOT exist
-        service_profile_exists = runner.file_exists("/etc/tuned/eks-generic-multiNodeTraining/tuned.conf")
+        profiles_dir = expected_profiles_dir(runner)
+        service_profile_exists = runner.file_exists(f"{profiles_dir}/eks-generic-multiNodeTraining/tuned.conf")
         assert not service_profile_exists, \
             "Service profile should not be created when accelerator=generic"
         
@@ -626,11 +656,12 @@ def test_prepare_nvidia_profiles_generic_profile_content(base_image):
         
         result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
         assert_exit_code(result, 0)
-        
+
+        profiles_dir = expected_profiles_dir(runner)
         profile_content = runner.get_file_contents(
-            "/etc/tuned/nvidia-generic/tuned.conf"
+            f"{profiles_dir}/nvidia-generic/tuned.conf"
         )
-        
+
         # Self-contained: no include directive
         assert "include=" not in profile_content, \
             "nvidia-generic should be self-contained with no include"
@@ -709,8 +740,9 @@ def test_prepare_nvidia_profiles_eks_service_specific_profile(base_image):
         
         # Verify that EKS-specific inference profile was deployed
         # (it should overwrite the OS profile)
+        profiles_dir = expected_profiles_dir(runner)
         inference_profile_content = runner.get_file_contents(
-            "/etc/tuned/nvidia-h100-inference/tuned.conf"
+            f"{profiles_dir}/nvidia-h100-inference/tuned.conf"
         )
         
         # EKS-specific profile should NOT have scheduler parameters set (they may be in comments)
@@ -752,9 +784,10 @@ def test_prepare_nvidia_profiles_aks_service_specific_profile(base_image):
         assert_exit_code(result, 0)
 
         # AKS-specific inference profile should have overwritten the OS profile
-        # at /etc/tuned/nvidia-h100-inference/tuned.conf
+        # at {profiles_dir}/nvidia-h100-inference/tuned.conf
+        profiles_dir = expected_profiles_dir(runner)
         inference_profile_content = runner.get_file_contents(
-            "/etc/tuned/nvidia-h100-inference/tuned.conf"
+            f"{profiles_dir}/nvidia-h100-inference/tuned.conf"
         )
 
         import re
@@ -798,7 +831,8 @@ def test_prepare_nvidia_profiles_common_service_rejected(base_image):
             f"Expected stdout to mention 'reserved service name', got: {result.stdout!r}"
 
         # No common-* final profile dir should have been created
-        assert not runner.file_exists("/etc/tuned/common-h100-performance/tuned.conf"), \
+        profiles_dir = expected_profiles_dir(runner)
+        assert not runner.file_exists(f"{profiles_dir}/common-h100-performance/tuned.conf"), \
             "common-h100-performance should NOT have been created"
 
     finally:
@@ -806,7 +840,7 @@ def test_prepare_nvidia_profiles_common_service_rejected(base_image):
 
 
 def test_prepare_nvidia_profiles_common_profiles_deployed(base_image):
-    """Test that common base profiles are deployed to /usr/lib/tuned/."""
+    """Test that common base profiles are deployed to the version-resolved profiles dir."""
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
         configmaps = {
@@ -826,11 +860,12 @@ def test_prepare_nvidia_profiles_common_profiles_deployed(base_image):
         assert_exit_code(result, 0)
 
         # Verify common profiles are deployed
-        nvidia_base_exists = runner.file_exists("/usr/lib/tuned/nvidia-base/tuned.conf")
-        assert nvidia_base_exists, "nvidia-base profile was not deployed to /usr/lib/tuned/"
+        profiles_dir = expected_profiles_dir(runner)
+        nvidia_base_exists = runner.file_exists(f"{profiles_dir}/nvidia-base/tuned.conf")
+        assert nvidia_base_exists, f"nvidia-base profile was not deployed to {profiles_dir}/"
 
-        nvidia_acs_disable_exists = runner.file_exists("/usr/lib/tuned/nvidia-acs-disable/tuned.conf")
-        assert nvidia_acs_disable_exists, "nvidia-acs-disable profile was not deployed to /usr/lib/tuned/"
+        nvidia_acs_disable_exists = runner.file_exists(f"{profiles_dir}/nvidia-acs-disable/tuned.conf")
+        assert nvidia_acs_disable_exists, f"nvidia-acs-disable profile was not deployed to {profiles_dir}/"
 
     finally:
         runner.cleanup()


### PR DESCRIPTION
## Summary

Part 2 of the version-aware tuned profile directory change. The `nvidia-tuned` package now deploys and verifies all NVIDIA tuned profiles in the single directory the installed tuned version reads from:

- tuned >= 2.23.0: `/etc/tuned/profiles`
- older tuned: `/etc/tuned`

Everything (common base, OS, and service profiles) goes to that one directory; nothing is written to `/usr/lib/tuned`. This fixes profiles being invisible to tuned on distros shipping tuned >= 2.23.0.

> Stacked on #86 (the `tuned` package change that adds the shared `resolve_tuned_profiles_dir` helper). This PR's base is the #86 branch so the diff shows only the Part 2 commits. After #86 merges, I will retarget the base to `main` (rebasing if #86 is squash-merged).

## Changes

- `skyhook_dir/prepare_nvidia_profiles.sh`: sources the inherited `utils.sh`, resolves `TUNED_PROFILES_DIR`, and deploys common + OS + service profiles to that single dir (drops the old `/usr/lib/tuned` system dir).
- `skyhook_dir/prepare_nvidia_profiles_check.sh`: sources `utils.sh` and verifies under the resolved dir.
- `tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py`: derives the expected dir from the container's tuned version and injects the parent `utils.sh` into test containers.
- `Dockerfile`: `ARG TUNED_VERSION` 1.2.0 -> 1.3.0 (the Part 1 release).
- `config.json`: `package_version` 0.3.0 -> 0.3.1.
- `RELEASE_NOTES.md`, `README.md`: document the version-aware directory.

## Sequencing

- Depends on #86: this needs `ghcr.io/nvidia/skyhook-packages/tuned:1.3.0` published, so `make validate-inherited` and the CI dev build will not pass until #86 is merged, tagged `tuned/1.3.0`, and its image is published.
- After merge, tag `nvidia-tuned/0.3.1`.

## Testing

The Docker-based integration suite and `make validate-inherited` were not run locally (they require the published `tuned:1.3.0` base image). In-session gates pass: `shellcheck` (no new findings beyond pre-existing style items), `python -m py_compile` on the test file, and `make license-check`.
