### PR TITLE
fix(tuned): match summary-bearing profiles in tuned-adm list validation

### DIFF
--- a/tests/unit/tuned/test_tuned_profile_matching.sh
+++ b/tests/unit/tuned/test_tuned_profile_matching.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dependency-free unit test for tuned_list_has_profile in tuned/skyhook_dir/utils.sh.
+# Runs with plain bash; needs no Docker and no installed tuned.
+#
+#   bash tests/unit/tuned/test_tuned_profile_matching.sh
+#
+# Regression guard for the bug where `tuned-adm list` drops the padding space
+# before the "- <summary>" column once a profile name is long enough, so a name
+# anchored match (`^- <name>$`) failed for every summary-bearing profile
+# (e.g. nvidia-gb200-multiNodeTraining).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UTILS="${SCRIPT_DIR}/../../../tuned/skyhook_dir/utils.sh"
+# shellcheck source=/dev/null
+source "${UTILS}"
+
+# Verbatim `tuned-adm list` output captured from the failing run. Note the two
+# multiNodeTraining lines: the 30/29-char names butt directly against the
+# "- <summary>" column with no separating space.
+read -r -d '' TUNED_ADM_LIST <<'EOF'
+Available profiles:
+- accelerator
+- balanced                     - General non-specialized tuned profile
+- hpc-compute                  - Optimize for HPC compute workloads
+- intent
+- nvidia-acs-disable           - Disable acs for pci
+- nvidia-base                  - Base NVIDIA tuning configuration
+- nvidia-gb200-inference       - Optimized for inference workloads
+- nvidia-gb200-multiNodeTraining- Optimized for multi-node distributed training
+- nvidia-gb200-performance     - TuneD Profile for DGX GB200
+- nvidia-generic               - NVIDIA Generic GPU Profile
+- nvidia-h100-inference        - Optimized for inference workloads
+- nvidia-h100-multiNodeTraining- Optimized for multi-node distributed training
+- nvidia-h100-performance      - NVIDIA H100 Performance Profile
+Current active profile: balanced
+EOF
+
+failures=0
+
+# assert_present <profile>: matcher must find it (exit 0)
+assert_present() {
+    if printf '%s\n' "${TUNED_ADM_LIST}" | tuned_list_has_profile "$1"; then
+        echo "ok: found '$1'"
+    else
+        echo "FAIL: expected to find profile '$1' but it was reported missing"
+        failures=$((failures + 1))
+    fi
+}
+
+# assert_absent <profile>: matcher must NOT find it (exit non-zero)
+assert_absent() {
+    if printf '%s\n' "${TUNED_ADM_LIST}" | tuned_list_has_profile "$1"; then
+        echo "FAIL: did not expect to find profile '$1' but it matched"
+        failures=$((failures + 1))
+    else
+        echo "ok: correctly absent '$1'"
+    fi
+}
+
+# The regression: long, summary-bearing names with no padding space.
+assert_present "nvidia-gb200-multiNodeTraining"
+assert_present "nvidia-h100-multiNodeTraining"
+
+# Summary-bearing names that ARE padded (also broke under the old `$` anchor).
+assert_present "nvidia-gb200-inference"
+assert_present "nvidia-base"
+assert_present "balanced"
+
+# Summary-less names (the only case the old anchor handled).
+assert_present "accelerator"
+assert_present "intent"
+
+# A name that is a prefix of others must not false-match the longer profiles.
+assert_absent "nvidia-gb200"
+assert_absent "nvidia-gb200-multiNode"
+assert_absent "does-not-exist"
+
+if [[ "${failures}" -ne 0 ]]; then
+    echo "FAILED: ${failures} assertion(s)"
+    exit 1
+fi
+echo "PASSED: all assertions"

--- a/tuned/RELEASE_NOTES.md
+++ b/tuned/RELEASE_NOTES.md
@@ -20,6 +20,17 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 1.3.1
+
+- Fixed profile validation so profiles that carry a `summary` in `tuned-adm
+  list` are recognized. The previous check matched the profile name anchored to
+  end-of-line, which only held for summary-less profiles; long, summary-bearing
+  names such as `nvidia-gb200-multiNodeTraining` (where `tuned-adm list` drops
+  the padding space before the summary) were reported as "not found" and the
+  `config` stage failed. No action is required. Consumers that inherit this
+  package (for example `nvidia-tuned`) pick up the fix by rebuilding on this
+  version.
+
 ## 1.3.0
 
 - Custom tuned profiles are now deployed to the directory the installed tuned

--- a/tuned/config.json
+++ b/tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "tuned",
-    "package_version": "1.3.0",
+    "package_version": "1.3.1",
     "expected_config_files": [],
     "modes": {
         "uninstall": [

--- a/tuned/skyhook_dir/apply_tuned_profile.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile.sh
@@ -86,9 +86,8 @@ if [ -f "$TUNED_PROFILE_FILE" ]; then
     check_tuned_version_for_multiple_profiles "$profile_count"
     
     # Validate each profile exists before applying
-    available_profiles=$(tuned-adm list)
     for profile in $tuned_profiles; do
-        if ! echo "$available_profiles" | grep -q "^- $profile$"; then
+        if ! tuned_profile_exists "$profile"; then
             echo "ERROR: tuned profile '$profile' not found"
             exit 1
         fi

--- a/tuned/skyhook_dir/apply_tuned_profile_check.sh
+++ b/tuned/skyhook_dir/apply_tuned_profile_check.sh
@@ -117,9 +117,8 @@ else
     check_tuned_version_for_multiple_profiles "$profile_count"
     
     # Validate each profile exists
-    available_profiles=$(tuned-adm list)
     for profile in $tuned_profiles; do
-        if ! echo "$available_profiles" | grep -q "^- $profile$"; then
+        if ! tuned_profile_exists "$profile"; then
             echo "ERROR: tuned profile '$profile' not found in tuned-adm list"
             exit 1
         fi

--- a/tuned/skyhook_dir/post_interrupt_tuned_check.sh
+++ b/tuned/skyhook_dir/post_interrupt_tuned_check.sh
@@ -110,9 +110,8 @@ else
     tuned_profiles=$(xargs < "$TUNED_PROFILE_FILE")
     
     # Validate each profile exists
-    available_profiles=$(tuned-adm list)
     for profile in $tuned_profiles; do
-        if ! echo "$available_profiles" | grep -q "^- $profile$"; then
+        if ! tuned_profile_exists "$profile"; then
             echo "ERROR: tuned profile '$profile' not found in tuned-adm list"
             exit 1
         fi

--- a/tuned/skyhook_dir/utils.sh
+++ b/tuned/skyhook_dir/utils.sh
@@ -98,3 +98,33 @@ resolve_tuned_profiles_dir() {
 
     echo "tuned $tuned_version: profiles dir is $TUNED_PROFILES_DIR"
 }
+
+# Return 0 if the named profile appears in `tuned-adm list` output read from
+# stdin, non-zero otherwise. This is the pure, testable half of
+# tuned_profile_exists.
+#
+# `tuned-adm list` pads the profile-name column to a fixed width and appends
+# "- <summary>" for profiles that define one:
+#
+#   - nvidia-gb200-inference       - Optimized for inference workloads
+#   - nvidia-gb200-multiNodeTraining- Optimized for multi-node distributed training
+#
+# Once a name is as long as the column, the padding space is dropped and the
+# summary butts directly against the name (second line above). Anchoring the
+# match to end-of-line (`^- <name>$`) therefore only matched summary-less
+# profiles. Accept the name followed by whitespace (padded), the "- " summary
+# separator (padding dropped), or end-of-line (no summary). Requiring a space
+# after the separator dash keeps a name from matching a longer profile whose
+# name merely starts with "<name>-" (e.g. nvidia-gb200 vs nvidia-gb200-inference).
+#
+# Usage: printf '%s\n' "$(tuned-adm list)" | tuned_list_has_profile <profile>
+tuned_list_has_profile() {
+    local profile="$1"
+    grep -qE "^- ${profile}([[:space:]]|-[[:space:]]|$)"
+}
+
+# Return 0 if <profile> is a profile the installed tuned knows about.
+# Usage: tuned_profile_exists <profile>
+tuned_profile_exists() {
+    tuned-adm list | tuned_list_has_profile "$1"
+}


### PR DESCRIPTION
## Problem

Applying an NVIDIA tuned profile fails the `config` stage with `ERROR: tuned profile '<name>' not found` even though the profile is installed. Surfaced by `nvidia-gb200-multiNodeTraining` (a 30-char name) in an nvidia-tuned run:

```
- nvidia-gb200-multiNodeTraining- Optimized for multi-node distributed training
+ grep -q '^- nvidia-gb200-multiNodeTraining$'
+ echo 'ERROR: tuned profile 'nvidia-gb200-multiNodeTraining' not found'
```

## Root cause

`tuned-adm list` pads the profile-name column to a fixed width and appends `- <summary>` for profiles that define one. Once a name reaches the column width the padding space is dropped and the summary butts directly against the name. The validation grepped for `^- <name>$`, anchored to end-of-line, so it only ever matched **summary-less** profiles. Every NVIDIA profile carries a summary, so validating any of them failed; the long name just made the missing space obvious. The same buggy check was copy-pasted in three scripts.

## Fix

- Add `tuned_list_has_profile` (pure, testable) and `tuned_profile_exists` (live wrapper) to `tuned/skyhook_dir/utils.sh`. The matcher accepts the name followed by whitespace (padded), the `- ` summary separator (padding dropped), or end-of-line (no summary), and requires a space after the separator dash so a name cannot false-match a longer profile (`nvidia-gb200` vs `nvidia-gb200-inference`).
- Route the three duplicated call sites through the shared helper: `apply_tuned_profile.sh`, `apply_tuned_profile_check.sh`, `post_interrupt_tuned_check.sh`.
- Bump `tuned` 1.3.0 → 1.3.1 and add a `## 1.3.1` RELEASE_NOTES section.

## Tests

- New dependency-free unit test `tests/unit/tuned/test_tuned_profile_matching.sh` runs the matcher against the verbatim `tuned-adm list` output from the failure (regression case + padded/summary-less cases + prefix false-match guard). Run: `bash tests/unit/tuned/test_tuned_profile_matching.sh`.
- `shellcheck` clean on all four scripts and the test.

## Follow-up (nvidia-tuned / #87)

The failing script is inherited from the published `tuned` image, not shipped by nvidia-tuned. Once `tuned/1.3.1` is released, nvidia-tuned's `preprocess.sh` selects the latest published `tuned` tag on rebuild, so #87 goes green without a code change; optionally bump `ARG TUNED_VERSION` default in `nvidia-tuned/Dockerfile` to `1.3.1`.