### PR TITLE
ci(general): build without pushing dev image on fork PRs

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -47,6 +47,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Whether to save image tags to an artifact (for PR builds)'
+  push:
+    required: false
+    default: 'true'
+    description: 'Whether to push the built image to the registry. Fork PRs get a read-only token that cannot push (and cannot create a new org package), so callers set this to false to build without publishing.'
   github_token:
     required: true
     description: 'GitHub token for registry authentication (pass secrets.GITHUB_TOKEN from the calling workflow)'
@@ -137,7 +141,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.package_name }}
-        push: true
+        push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -276,6 +276,10 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}
           generate_attestation: 'false'
           save_image_info: 'true'
+          # Fork PRs run with a read-only GITHUB_TOKEN and no secrets, so a push
+          # (which for a new package also means creating an org package) is denied.
+          # Build without publishing on forks; same-repo PRs still push a dev image.
+          push: ${{ github.event.pull_request.head.repo.fork == false }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Summary job to report status


### PR DESCRIPTION
## Problem

`pr_build.yaml` runs on `pull_request`. For PRs **from a fork**, GitHub forces `GITHUB_TOKEN` to read-only and withholds secrets, so the `Build and push Docker image` step cannot push to `ghcr.io`. When the changed package is brand-new (no existing GHCR package), this surfaces as:

```
denied: installation not allowed to Create organization package
```

and fails CI on an otherwise-valid contribution (e.g. PR #89 `bind-mount`). The contributor cannot fix this from the fork.

## Change

- Add a `push` input to the `build-package` composite action, defaulting to `'true'` so the release-tag build (`build_container.yaml`) and same-repo PRs are unchanged. The `docker/build-push-action` step now uses `push: ${{ inputs.push }}`.
- In `pr_build.yaml`, set `push: ${{ github.event.pull_request.head.repo.fork == false }}`.

On fork PRs the image is still **built** (so the `Dockerfile` is validated) but not published. Same-repo PRs continue to push a `<version>-dev.sha<short>` image exactly as before.

## Scope / not touched

- `build_container.yaml` (release-tag build) only ever runs from this repo, so it keeps the default `push: true` and is intentionally left alone.
- The registry login step is unchanged: it still runs so inherited packages can pull their base image; only the publish is gated.

## Notes

This does not, by itself, let a fork publish a new package. Publishing `bind-mount` still needs the one-time org-side package creation + repo access grant, done from an internal branch or the release tag. This PR just stops fork PRs from red-failing on a push they can never perform.