### PR TITLE
fix(nvidia-setup): eks-gb200 EFA on 6.17 (efa 1.49.0 + kernel prune)

### DIFF
--- a/nvidia-setup/CHANGELOG.md
+++ b/nvidia-setup/CHANGELOG.md
@@ -5,7 +5,15 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [0.5.1] - 2026-07-13
+
+### Bug Fixes
+
+- *(nvidia-setup)* Eks-gb200 EFA on 6.17 (efa 1.49.0 + kernel prune)
+
+### Other Tasks
+
+- *(general)* Regenerate package changelogs to current tags 
 
 
 ## [0.5.0] - 2026-07-09

--- a/nvidia-setup/README.md
+++ b/nvidia-setup/README.md
@@ -16,15 +16,19 @@ A NodeWright package that applies node setup steps for selected (service, accele
 
 See [VERSION_OVERVIEW.md](VERSION_OVERVIEW.md) for more information about what is set in each version of the package.
 
-| service | accelerator | default kernel      |  default efa |
-|---------|-------------|---------------------|--------------|
-| eks     | h100        | 6.17.0-1019-aws     |  1.48.0      |
-| eks     | gb200       | 6.17.0-1019-aws     |  1.48.0      |
-| aks     | h100        | (AKS-managed)       |  n/a         |
-| bcm     | h100        | n/a                 |  n/a         |
-| bcm     | gb200       | n/a                 |  n/a         |
+| service | accelerator | default kernel      |  default efa | efa-build pod resources |
+|---------|-------------|---------------------|--------------|-------------------------|
+| eks     | h100        | 6.17.0-1019-aws     |  1.48.0      | 8 CPU / 16Gi (min)      |
+| eks     | gb200       | 6.17.0-1019-aws-64k |  1.49.0      | 8 CPU / 16Gi (min)      |
+| aks     | h100        | (AKS-managed)       |  n/a         | default (no EFA build)  |
+| bcm     | h100        | n/a                 |  n/a         | default (no EFA build)  |
+| bcm     | gb200       | n/a                 |  n/a         | default (no EFA build)  |
 
 Defaults are defined in `skyhook_dir/defaults/eks-h100.conf`, `eks-gb200.conf`, and `aks-h100.conf`. The `bcm-*` defaults files are intentionally empty: the `bcm` service only runs the kernel-headers alias and does not bake in any kernel/EFA/lustre versions. Keep this table in sync when adding or changing defaults.
+
+GB200 (Grace) is arm64, so it always runs the `-64k` page-size kernel: the conf stores the base version (`KERNEL=6.17.0-1019-aws`) and `resolve_full_kernel` appends `-64k` at apply time. H100 (x86_64) uses the flavour as-is.
+
+**EFA-build pod resources:** the `nvidia-setup-full` package builds the EFA kernel module via DKMS, whose `efa_installer.sh` "Inspecting kernel" step is a highly parallel kernel-module autoconf. Inside the skyhook chroot `nproc` reports the host core count, so `make -j` oversubscribes the pod cgroup. Under tight limits (for example 4 CPU / 8Gi) the build is CFS-throttled and its feature probes are starved or OOM-killed, which makes `efa` misdetect the kernel and emit compat shims that fail to compile (DKMS build error 2, aborting the apply). Give the `nvidia-setup-full` package pod **at least 8 CPU / 16Gi** via `spec.packages.nvidia-setup-full.resources` in the NodeWright Custom Resource. The kernel-only `nvidia-setup-kernel` package does not build EFA and does not need the extra headroom.
 
 ## Configuration
 
@@ -75,7 +79,8 @@ For `service=eks` the apply step currently runs, in order:
 
 1. **ensure_kernel** – if `NVIDIA_SETUP_INSTALL_KERNEL=false`: verify running kernel meets requirement (exact match by default; allow newer if `NVIDIA_SETUP_KERNEL_ALLOW_NEWER=true`); if `true`: install exact kernel only (then exit; reboot required).
 2. **upgrade** – `apt-get update && apt-get upgrade -y`
-3. **install-efa-driver** – download and run AWS EFA installer
+3. **prune non-running kernels** – remove every installed kernel except the running one (`prune_foreign_kernels` in `utilities.sh`), so the EFA DKMS build only ever targets the booted/target kernel. A stray non-running kernel left by the base AMI would otherwise fail the DKMS build and abort the EFA install. On a 64k node it also purges the 4k page-size sibling flavour's meta packages (`linux-image-aws` etc.) so apt cannot re-pull a 4k kernel to satisfy them. The running kernel and its flavour metas are never removed.
+4. **install-efa-driver** – download and run AWS EFA installer
 
 The following steps exist in the codebase but are **commented out** in `apply.sh` for now: **install-lustre** Re-enable them in `apply.sh` when needed.
 

--- a/nvidia-setup/RELEASE_NOTES.md
+++ b/nvidia-setup/RELEASE_NOTES.md
@@ -19,3 +19,34 @@ example is not itself picked up as release notes):
 
     - Notable behavior change worth calling out.
 -->
+
+## 0.5.1
+
+EFA fix (eks-gb200): bump the EFA installer from 1.48.0 to 1.49.0. EFA installer
+1.48.0's `efa` DKMS module fails to build against the 6.17 arm64 kernel in the
+apply flow: its kernel autoconf misdetects the kernel and falls back to a
+pre-4.20 RDMA API (direct `ib_device` function-pointer assignment, single-arg
+`ib_alloc_device`) that does not compile on 6.17, which aborts the EFA install.
+1.49.0 builds cleanly. H100 (x86_64) stays on 1.48.0.
+
+Behavior change (eks): apply now removes every installed kernel except the
+running one before installing the EFA driver. The EFA `.deb` post-install builds
+its `efa` DKMS module against every installed kernel that still has headers, and
+a single failed build returns a dpkg error that aborts the whole EFA install. A
+non-running `*-aws` kernel left behind by the base AMI (or re-pulled by
+`apt-get upgrade`) triggered exactly that on Grace/arm64 nodes: EFA built cleanly
+for the booted `-64k` kernel but failed for the stray 4k kernel. Pruning
+non-running kernels leaves DKMS only the booted/target kernel to build against.
+
+On a 64k (Grace/arm64) node the prune also purges the 4k page-size sibling
+flavour's meta packages (`linux-aws`, `linux-image-aws`, `linux-headers-aws`,
+`linux-tools-aws`) in the same transaction. Removing only the concrete 4k kernel
+is not enough: its meta package makes apt upgrade the meta and re-pull a fresh 4k
+kernel to satisfy it, so the failing DKMS build target reappears. The running
+flavour's own metas are always kept.
+
+Operator impact: on eks nodes there is no longer a spare (fallback) kernel after
+apply; only the running/target kernel and its flavour remain. The running kernel
+is never removed. The kernel-only install pass (`NVIDIA_SETUP_INSTALL_KERNEL=true`)
+additionally keeps the freshly installed target that is not yet booted; the
+previous running kernel is pruned on the next, post-reboot apply.

--- a/nvidia-setup/VERSION_OVERVIEW.md
+++ b/nvidia-setup/VERSION_OVERVIEW.md
@@ -38,10 +38,12 @@ Bumps EKS defaults to kernel `6.17.0-1019-aws` and EFA `1.48.0`. `resolve_full_k
 
 Adds the `aks` service with the `aks-h100` combination. For `service=aks` the apply stage runs a single `configure_ib_rdma` step that loads the InfiniBand kernel modules (`ib_umad`, best-effort `rdma_ucm`/`ib_ucm`), persists them via `/etc/modules-load.d/ib-umad.conf`, writes memlock limits to `/etc/security/limits.d/99-ib-memlock.conf`, and sets `LimitMEMLOCK=infinity` on containerd and kubelet through systemd drop-ins. Service restarts are handled by the Skyhook interrupt declared in the CR, not by the package. The kernel/EFA pipeline does not run on AKS (AKS manages its own Ubuntu kernel), and `ensure_kernel` no-ops when `KERNEL` is unset.
 
+0.5.1 bumps the eks-gb200 EFA installer to `1.49.0` (H100/x86_64 stays on `1.48.0`): 1.48.0's `efa` DKMS module fails to build against the 6.17 arm64 kernel in the apply flow (its kernel autoconf misdetects the kernel and falls back to a pre-4.20 RDMA API that does not compile), while 1.49.0 builds cleanly. 0.5.1 also removes every installed kernel except the running one before the EFA install (`prune_foreign_kernels`), so EFA's `efa` DKMS module is only ever built against the booted/target kernel. A stray non-running kernel (for example the base-AMI 4k `*-aws` kernel on a Grace node running the `-64k` kernel) previously made the EFA `.deb` post-install fail its DKMS build and abort the whole apply. On a 64k node the prune also purges the 4k sibling flavour's meta packages (`linux-image-aws` etc.) in the same transaction, so apt cannot upgrade the meta and re-pull a fresh 4k kernel.
+
 | service | accelerator | kernel              | efa         | chrony | raid0 | OFI | bcm headers alias | ib rdma memlock |
 |---------|-------------|---------------------|-------------|--------|-------|-----|-------------------|-----------------|
 | eks     | h100        | 6.17.0-1019-aws     | 1.48.0      |  Y     |  Y    |  Y  |  N                |  N              |
-| eks     | gb200       | 6.17.0-1019-aws-64k | 1.48.0      |  Y     |  Y    |  Y  |  N                |  N              |
+| eks     | gb200       | 6.17.0-1019-aws-64k | 1.49.0      |  Y     |  Y    |  Y  |  N                |  N              |
 | aks     | h100        | (AKS-managed)       | n/a         |  N     |  N    |  N  |  N                |  Y              |
 | bcm     | h100        | n/a                 | n/a         |  N     |  N    |  N  |  Y                |  N              |
 | bcm     | gb200       | n/a                 | n/a         |  N     |  N    |  N  |  Y                |  N              |

--- a/nvidia-setup/config.json
+++ b/nvidia-setup/config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "v1",
   "package_name": "nvidia_setup",
-  "package_version": "0.5.0",
+  "package_version": "0.5.1",
   "expected_config_files": ["service", "accelerator"],
   "modes": {
     "apply": [

--- a/nvidia-setup/skyhook_dir/apply.sh
+++ b/nvidia-setup/skyhook_dir/apply.sh
@@ -21,6 +21,8 @@ STEPS_DIR="${SKYHOOK_DIR}/skyhook_dir/steps"
 
 # shellcheck source=load_defaults.sh
 . "${SKYHOOK_DIR}/skyhook_dir/load_defaults.sh"
+# shellcheck source=utilities.sh
+. "${SKYHOOK_DIR}/skyhook_dir/utilities.sh"
 
 NVIDIA_SETUP_INSTALL_KERNEL="${NVIDIA_SETUP_INSTALL_KERNEL:-false}"
 export NVIDIA_SETUP_INSTALL_KERNEL SKYHOOK_DIR
@@ -43,6 +45,9 @@ fi
 
 run_eks_h100() {
   "${STEPS_DIR}/upgrade.sh"
+  # Drop any non-running kernel before EFA so its DKMS build only ever targets
+  # the booted/target kernel (see prune_foreign_kernels in utilities.sh).
+  prune_foreign_kernels
   "${STEPS_DIR}/install-efa-driver.sh" "${EFA}"
   "${STEPS_DIR}/install_ofi.sh"
   # "${STEPS_DIR}/install-lustre.sh" "${KERNEL}" "${LUSTRE}"
@@ -52,6 +57,9 @@ run_eks_h100() {
 
 run_eks_gb200() {
   "${STEPS_DIR}/upgrade.sh"
+  # Drop any non-running kernel before EFA so its DKMS build only ever targets
+  # the booted/target kernel (see prune_foreign_kernels in utilities.sh).
+  prune_foreign_kernels
   "${STEPS_DIR}/install-efa-driver.sh" "${EFA}"
   "${STEPS_DIR}/install_ofi.sh"
   # "${STEPS_DIR}/install-lustre.sh" "${KERNEL}" "${LUSTRE}"

--- a/nvidia-setup/skyhook_dir/defaults/eks-gb200.conf
+++ b/nvidia-setup/skyhook_dir/defaults/eks-gb200.conf
@@ -1,4 +1,4 @@
 # EKS + GB200: opinionated defaults (override via NVIDIA_* env vars)
 KERNEL=6.17.0-1019-aws
 LUSTRE=aws
-EFA=1.48.0
+EFA=1.49.0

--- a/nvidia-setup/skyhook_dir/steps/install_kernel.sh
+++ b/nvidia-setup/skyhook_dir/steps/install_kernel.sh
@@ -112,14 +112,20 @@ EOF
     if [[ $CURRENT_KERNEL_VERSION != "${full_kernel_ver}" ]]; then
       # Hold the Kernel packages
       apt-mark hold \
-        linux-image-$full_kernel_ver \
-        linux-headers-$full_kernel_ver \
-        linux-modules-$full_kernel_ver \
-        linux-modules-extra-$full_kernel_ver
+        "linux-image-${full_kernel_ver}" \
+        "linux-headers-${full_kernel_ver}" \
+        "linux-modules-${full_kernel_ver}" \
+        "linux-modules-extra-${full_kernel_ver}"
     fi
 
   fi
 
+  # Remove any kernel other than the one running now and the target just
+  # installed, so out-of-tree DKMS modules (EFA) never build against a stray
+  # kernel. The still-running pre-reboot kernel is preserved here (it cannot be
+  # removed while booted) and is pruned on the next, post-reboot apply, when it
+  # is no longer running.
+  prune_foreign_kernels "${full_kernel_ver}"
 }
 
 if [ -n "${SKIP_SYSTEM_OPERATIONS:-}" ]; then

--- a/nvidia-setup/skyhook_dir/utilities.sh
+++ b/nvidia-setup/skyhook_dir/utilities.sh
@@ -47,3 +47,137 @@ resolve_full_kernel() {
       ;;
   esac
 }
+
+# prune_foreign_kernels [keep_version...]
+#
+# Purge every installed kernel except the running one, plus any additional
+# kernel versions passed as arguments (e.g. a freshly installed target that is
+# not yet booted). The running kernel is never removed.
+#
+# Why this exists: out-of-tree DKMS modules (EFA's efa, efa-nv-peermem) are
+# built by `dkms autoinstall`, which the EFA .deb post-install runs for every
+# installed kernel that still has headers. A single failing build there returns
+# a dpkg error and aborts the whole EFA install. On Grace/arm64 the base AMI
+# ships the 4k `-aws` flavour alongside the booted 64k `-aws-64k` kernel, and
+# EFA 3.0.0's kcompat shims do not compile against the 4k arm64 headers: DKMS
+# tries to build EFA for a kernel the node does not even run, and it fails.
+#
+# Removing only the concrete 4k kernel is NOT enough: its `linux-image-<sib>`
+# meta package (e.g. linux-image-aws) then makes apt UPGRADE the meta and pull a
+# fresh 4k kernel to satisfy it, so the build target reappears. This function
+# therefore also purges the page-size sibling flavour's meta packages
+# (linux-<sib>, linux-image-<sib>, linux-headers-<sib>, linux-tools-<sib>) in the
+# same transaction, so the sibling flavour stays gone. The running flavour's own
+# metas are always kept.
+#
+# When SKIP_SYSTEM_OPERATIONS is set the selection is logged but no apt
+# operation runs (used by tests and dry runs).
+prune_foreign_kernels() {
+  local running
+  running="$(uname -r)"
+  if [ -z "${running}" ]; then
+    echo "prune_foreign_kernels: could not determine running kernel; refusing to prune" >&2
+    return 1
+  fi
+
+  local -a keep=("${running}" "$@")
+
+  # Page-size flavour of each kept kernel (e.g. 6.17.0-1019-aws-64k -> aws-64k),
+  # derived by stripping the leading "<upstream>-<abi>-".
+  local -a keep_flavours=()
+  local kv
+  for kv in "${keep[@]}"; do
+    keep_flavours+=("${kv#*-*-}")
+  done
+
+  # Concrete, versioned kernel images only (e.g. linux-image-6.17.0-1017-aws).
+  # The [0-9] class right after the prefix skips meta packages such as
+  # linux-image-aws / linux-image-aws-64k, which carry no version of their own.
+  local -a versions=()
+  local line
+  while IFS= read -r line; do
+    [ -n "${line}" ] && versions+=("${line}")
+  done < <(
+    dpkg-query -W -f='${Package}\n' 'linux-image-[0-9]*' 2>/dev/null \
+      | sed -n 's/^linux-image-//p' || true
+  )
+
+  local -a foreign=()
+  local ver k kept
+  for ver in "${versions[@]}"; do
+    [ -n "${ver}" ] || continue
+    kept=0
+    for k in "${keep[@]}"; do
+      if [ "${ver}" = "${k}" ]; then
+        kept=1
+        break
+      fi
+    done
+    [ "${kept}" -eq 1 ] || foreign+=("${ver}")
+  done
+
+  # Family packages for each foreign kernel version.
+  local -a candidates=()
+  for ver in "${foreign[@]}"; do
+    candidates+=(
+      "linux-image-${ver}"
+      "linux-headers-${ver}"
+      "linux-modules-${ver}"
+      "linux-modules-extra-${ver}"
+    )
+  done
+
+  # Sibling-flavour meta packages. When the running kernel is a 64k flavour, its
+  # 4k page-size sibling (aws-64k -> aws) is never used on this node; purge that
+  # sibling's metas so apt cannot re-pull a 4k kernel to satisfy them. Skip if the
+  # sibling flavour is itself something we are keeping.
+  local running_flavour="${running#*-*-}"
+  case "${running_flavour}" in
+    *-64k)
+      local sib="${running_flavour%-64k}"
+      local keep_sib=0 kf
+      for kf in "${keep_flavours[@]}"; do
+        if [ "${kf}" = "${sib}" ]; then
+          keep_sib=1
+          break
+        fi
+      done
+      if [ "${keep_sib}" -eq 0 ]; then
+        candidates+=(
+          "linux-${sib}"
+          "linux-image-${sib}"
+          "linux-headers-${sib}"
+          "linux-tools-${sib}"
+        )
+      fi
+      ;;
+  esac
+
+  # Keep only packages that are actually installed, so a missing family member
+  # (e.g. a kernel with no linux-modules-extra, or an absent sibling meta) is not
+  # an "Unable to locate package" hard error.
+  local -a purge=()
+  local p
+  for p in "${candidates[@]}"; do
+    if dpkg-query -W -f='${Status}\n' "${p}" 2>/dev/null | grep -q 'ok installed'; then
+      purge+=("${p}")
+    fi
+  done
+
+  if [ "${#purge[@]}" -eq 0 ]; then
+    echo "prune_foreign_kernels: nothing to prune (keeping: ${keep[*]})"
+    return 0
+  fi
+
+  echo "prune_foreign_kernels: keeping ${keep[*]}; purging ${purge[*]}"
+
+  if [ -n "${SKIP_SYSTEM_OPERATIONS:-}" ]; then
+    echo "prune_foreign_kernels: SKIP_SYSTEM_OPERATIONS set; would purge: ${purge[*]}"
+    return 0
+  fi
+
+  # Purge the concrete foreign kernels and the sibling metas together so apt
+  # removes the meta instead of upgrading it and re-pulling a sibling kernel.
+  DEBIAN_FRONTEND=noninteractive apt-get purge -y "${purge[@]}"
+  DEBIAN_FRONTEND=noninteractive apt-get autoremove -y --purge
+}

--- a/tests/integration/nvidia_setup/run_prune_foreign_kernels_test.sh
+++ b/tests/integration/nvidia_setup/run_prune_foreign_kernels_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test harness for prune_foreign_kernels in utilities.sh.
+#
+# Inputs (env):
+#   RUNNING_KERNEL     - value returned by `uname -r` (required)
+#   INSTALLED_PACKAGES - space-separated list of installed kernel-related package
+#                        names (concrete kernels AND flavour meta packages) that
+#                        the mocked dpkg-query should report. The enumeration
+#                        query returns the linux-image-<version> entries; the
+#                        status query reports any listed package as installed.
+#   KEEP_EXTRA         - optional space-separated extra kernel versions to keep
+#                        (e.g. a freshly installed target not yet booted)
+#
+# Mocks uname and dpkg-query, sources utilities.sh, and runs prune_foreign_kernels
+# with SKIP_SYSTEM_OPERATIONS set so no apt operation runs; the resolved purge set
+# is printed to stdout for the caller to assert on. Exit code mirrors the function.
+set -e
+
+RUNNING_KERNEL="${RUNNING_KERNEL:?RUNNING_KERNEL must be set}"
+INSTALLED_PACKAGES="${INSTALLED_PACKAGES:-}"
+KEEP_EXTRA="${KEEP_EXTRA:-}"
+[ -n "${SKYHOOK_DIR:-}" ] || { echo "SKYHOOK_DIR must be set" >&2; exit 1; }
+
+uname() {
+  if [ "$1" = "-r" ]; then
+    echo "${RUNNING_KERNEL}"
+  else
+    /usr/bin/uname "$@"
+  fi
+}
+
+# Mock dpkg-query for the two shapes prune_foreign_kernels uses:
+#   enumeration:  -W -f='${Package}\n' 'linux-image-[0-9]*'  -> installed images
+#   status query: -W -f='${Status}\n' <package>              -> "install ok installed"
+dpkg-query() {
+  if printf '%s\n' "$@" | grep -q 'Package'; then
+    local pkg
+    for pkg in ${INSTALLED_PACKAGES}; do
+      case "${pkg}" in
+        linux-image-[0-9]*) echo "${pkg}" ;;
+      esac
+    done
+    return 0
+  fi
+  local want
+  for want in "$@"; do :; done
+  local q
+  for q in ${INSTALLED_PACKAGES}; do
+    if [ "${q}" = "${want}" ]; then
+      echo "install ok installed"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Force dry-run: the harness only exercises the selection logic, never apt.
+export SKIP_SYSTEM_OPERATIONS=1
+
+# shellcheck source=/dev/null
+. "${SKYHOOK_DIR}/skyhook_dir/utilities.sh"
+
+# KEEP_EXTRA is an intentional word-split list of extra versions to keep.
+# shellcheck disable=SC2086
+prune_foreign_kernels ${KEEP_EXTRA}
+exit $?

--- a/tests/integration/nvidia_setup/test_prune_foreign_kernels.py
+++ b/tests/integration/nvidia_setup/test_prune_foreign_kernels.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for prune_foreign_kernels in utilities.sh.
+
+prune_foreign_kernels purges every installed kernel except the running one (plus
+optional keep-extra versions) so out-of-tree DKMS modules (EFA) are only built
+against the booted/target kernel. On a 64k running kernel it also purges the 4k
+page-size sibling flavour's meta packages, otherwise apt upgrades the meta and
+re-pulls a 4k kernel that EFA 3.0.0 cannot build against on arm64.
+
+The harness mocks uname/dpkg-query and runs the function in SKIP_SYSTEM_OPERATIONS
+dry-run, so these assert the resolved purge set, not the apt purge itself.
+"""
+
+from pathlib import Path
+
+from tests.helpers.assertions import (
+    assert_exit_code,
+    assert_output_contains,
+    assert_output_not_contains,
+)
+from tests.helpers.docker_test import DockerTestRunner
+
+# Test script lives with tests and is copied into the package at run time.
+_PRUNE_SCRIPT_SOURCE = Path(__file__).parent / "run_prune_foreign_kernels_test.sh"
+_PRUNE_SCRIPT_DEST = "skyhook_dir/steps/run_prune_foreign_kernels_test.sh"
+
+
+def _run_prune(runner, running, installed_packages, keep_extra=""):
+    """Run the prune harness; return the TestResult."""
+    env = {
+        "RUNNING_KERNEL": running,
+        "INSTALLED_PACKAGES": " ".join(installed_packages),
+    }
+    if keep_extra:
+        env["KEEP_EXTRA"] = keep_extra
+    return runner.run_script(
+        script="steps/run_prune_foreign_kernels_test.sh",
+        configmaps={},
+        env_vars=env,
+        extra_files=[(_PRUNE_SCRIPT_SOURCE, _PRUNE_SCRIPT_DEST)],
+    )
+
+
+def test_prunes_stray_kernel_and_sibling_metas():
+    """Stray 1017-aws concrete kernel and the 4k sibling metas are purged; the running 64k kernel is kept."""
+    runner = DockerTestRunner(package="nvidia-setup")
+    try:
+        result = _run_prune(
+            runner,
+            running="6.17.0-1019-aws-64k",
+            installed_packages=[
+                "linux-image-6.17.0-1019-aws-64k",
+                "linux-image-6.17.0-1017-aws",
+                "linux-headers-6.17.0-1017-aws",
+                "linux-modules-6.17.0-1017-aws",
+                "linux-aws",
+                "linux-image-aws",
+                "linux-headers-aws",
+            ],
+        )
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "linux-image-6.17.0-1017-aws")
+        # The 4k sibling meta must be purged too, or apt re-pulls a 4k kernel.
+        assert_output_contains(result.stdout, "linux-image-aws")
+        assert_output_contains(result.stdout, "linux-aws")
+        # The running kernel and any package not installed are never purged.
+        assert_output_not_contains(result.stdout, "linux-image-6.17.0-1019-aws-64k")
+        assert_output_not_contains(result.stdout, "linux-tools-aws")
+    finally:
+        runner.cleanup()
+
+
+def test_prunes_4k_sibling_kernel_and_meta_regression():
+    """Regression: after the meta upgraded to the same ABI, the 4k 1019-aws kernel and its meta must both be purged."""
+    runner = DockerTestRunner(package="nvidia-setup")
+    try:
+        result = _run_prune(
+            runner,
+            running="6.17.0-1019-aws-64k",
+            installed_packages=[
+                "linux-image-6.17.0-1019-aws-64k",
+                "linux-image-6.17.0-1019-aws",
+                "linux-headers-6.17.0-1019-aws",
+                "linux-modules-6.17.0-1019-aws",
+                "linux-aws",
+                "linux-image-aws",
+                "linux-headers-aws",
+            ],
+        )
+        assert_exit_code(result, 0)
+        # Exact match, not prefix: the 4k 1019-aws kernel is foreign to the 64k running kernel.
+        assert_output_contains(result.stdout, "linux-image-6.17.0-1019-aws")
+        assert_output_contains(result.stdout, "linux-image-aws")
+        # The 64k running kernel is kept.
+        assert_output_not_contains(result.stdout, "linux-image-6.17.0-1019-aws-64k")
+    finally:
+        runner.cleanup()
+
+
+def test_clean_64k_only_is_a_no_op():
+    """When only the running 64k kernel and its own 64k metas are installed there is nothing to prune."""
+    runner = DockerTestRunner(package="nvidia-setup")
+    try:
+        result = _run_prune(
+            runner,
+            running="6.17.0-1019-aws-64k",
+            installed_packages=[
+                "linux-image-6.17.0-1019-aws-64k",
+                "linux-image-aws-64k",
+                "linux-headers-aws-64k",
+                "linux-aws-64k",
+            ],
+        )
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "nothing to prune")
+        # The running flavour's own metas must never be purged.
+        assert_output_not_contains(result.stdout, "linux-image-aws-64k")
+    finally:
+        runner.cleanup()
+
+
+def test_install_pass_keep_extra_preserves_unbooted_target():
+    """Install-pass case: running the old 4k kernel, keep the just-installed 64k target; prune nothing (no 64k sibling logic while on 4k)."""
+    runner = DockerTestRunner(package="nvidia-setup")
+    try:
+        result = _run_prune(
+            runner,
+            running="6.17.0-1017-aws",
+            installed_packages=[
+                "linux-image-6.17.0-1017-aws",
+                "linux-image-6.17.0-1019-aws-64k",
+                "linux-aws",
+                "linux-image-aws",
+            ],
+            keep_extra="6.17.0-1019-aws-64k",
+        )
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "nothing to prune")
+        # The not-yet-booted target must be kept.
+        assert_output_not_contains(result.stdout, "linux-image-6.17.0-1019-aws-64k")
+    finally:
+        runner.cleanup()


### PR DESCRIPTION
## Description

`eks-gb200` apply aborts at the EFA step on Grace/arm64. This PR makes two package-level improvements and documents the pod-resource requirement that turned out to be the actual root-cause fix.

### 1. Prune non-running kernels before the EFA build

`dkms autoinstall` (run by the `efa` .deb post-install) builds the `efa` module for every installed kernel that has headers. On Grace the base AMI leaves the 4k `*-aws` kernel installed alongside the booted 64k `*-aws-64k` kernel, so DKMS also tried (and failed) to build for a kernel the node does not run.

`prune_foreign_kernels()` in `utilities.sh` purges every installed kernel except the running one (plus optional keep-extras) before the EFA step, and on a 64k node also purges the 4k page-size sibling flavour's meta packages (`linux-image-aws` etc.) so apt cannot re-pull a 4k kernel. Wired into the eks apply path (after `upgrade.sh`, before EFA) and the end of `downgrade_kernel`. The running flavour's own metas are never removed.

### 2. EFA installer 1.48.0 to 1.49.0 for eks-gb200

Bumps eks-gb200 to the newer EFA installer (efa driver 3.1.0); H100 (x86_64) stays on 1.48.0.

### Root cause and the actual fix (pod resources)

The gb200 EFA build failure turned out to be **resource starvation**, not the EFA version or stray kernels. The `nvidia-setup-full` EFA build's "Inspecting kernel" autoconf is a highly parallel kernel-module build; inside the skyhook chroot `nproc` reports the host core count, so `make -j` oversubscribes the pod cgroup. Under the prior 4 CPU / 8Gi limit it was CFS-throttled and its feature probes were starved or OOM-killed, so `efa` misdetected the 6.17 kernel and failed to compile (on both efa 3.0.0 and 3.1.0). The same `dkms build` succeeds in ~3.4s unconstrained.

The resource fix itself lives in the consumer (AICR, NVIDIA/aicr#1738, raises `nvidia-setup-full` to 8 CPU / 16Gi). This PR **documents that requirement** in the package README (new "efa-build pod resources" column + note) so any consumer allocates enough. The prune and the EFA 1.49.0 bump remain correct package improvements, but neither alone fixes the build.

### Testing

- `test_prune_foreign_kernels.py` + `run_prune_foreign_kernels_test.sh`: 4 cases (stray kernel + sibling metas purged; the 4k-1019 sibling regression; clean 64k no-op; install-pass keep-extra no-op). Selection logic also exercised locally on bash 5 and bash 3.2; `shellcheck` and `make license-check` clean.
- EFA 1.49.0 confirmed installing on a gb200 node (with adequate pod resources).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
