### PR TITLE
fix(nvidia-tuned): remove isolcpus from all inference profiles

### DIFF
--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.3.1",
+    "package_version": "0.3.2",
     "expected_config_files": ["accelerator"],
     "modes": {
         "uninstall": [

--- a/nvidia-tuned/profiles/os/common/nvidia-gb200-inference/tuned.conf
+++ b/nvidia-tuned/profiles/os/common/nvidia-gb200-inference/tuned.conf
@@ -3,8 +3,6 @@ include=nvidia-gb200-performance
 summary=Optimized for inference workloads
 
 [bootloader]
-# Isolate CPUs for inference processes, 2 per socket
-cmdline_isolcpus=isolcpus=${f:cpulist_invert:${f:calc_isolated_cores:2}}
 # Allocate hugepages for better memory access
 cmdline_hugepages=hugepagesz=2M hugepages=8192
 

--- a/nvidia-tuned/profiles/os/common/nvidia-h100-inference/tuned.conf
+++ b/nvidia-tuned/profiles/os/common/nvidia-h100-inference/tuned.conf
@@ -3,8 +3,6 @@ include=nvidia-h100-performance
 summary=Optimized for inference workloads
 
 [bootloader]
-# Isolate CPUs for inference processes, 2 per socket
-cmdline_isolcpus=isolcpus=${f:cpulist_invert:${f:calc_isolated_cores:2}}
 # Allocate hugepages for better memory access
 cmdline_hugepages=hugepagesz=2M hugepages=8192
 

--- a/nvidia-tuned/profiles/os/debian/11/nvidia-gb200-inference/tuned.conf
+++ b/nvidia-tuned/profiles/os/debian/11/nvidia-gb200-inference/tuned.conf
@@ -1,6 +1,6 @@
 [main]
 include=nvidia-gb200-performance
-summary=Optimized for inference workloads. Without cpu isolation due to tuned package version.
+summary=Optimized for inference workloads
 
 [bootloader]
 # Allocate hugepages for better memory access

--- a/nvidia-tuned/profiles/os/ubuntu/22.04/nvidia-gb200-inference/tuned.conf
+++ b/nvidia-tuned/profiles/os/ubuntu/22.04/nvidia-gb200-inference/tuned.conf
@@ -1,6 +1,6 @@
 [main]
 include=nvidia-gb200-performance
-summary=Optimized for inference workloads. Without cpu isolation due to tuned package version.
+summary=Optimized for inference workloads
 
 [bootloader]
 # Allocate hugepages for better memory access

--- a/nvidia-tuned/profiles/service/aks/nvidia-h100-inference.conf
+++ b/nvidia-tuned/profiles/service/aks/nvidia-h100-inference.conf
@@ -3,8 +3,6 @@ include=nvidia-h100-performance
 summary=Optimized for inference workloads (AKS-compatible)
 
 [bootloader]
-# Isolate CPUs for inference processes, 2 per socket
-cmdline_isolcpus=isolcpus=${f:cpulist_invert:${f:calc_isolated_cores:2}}
 # Allocate hugepages for better memory access
 cmdline_hugepages=hugepagesz=2M hugepages=8192
 

--- a/nvidia-tuned/profiles/service/eks/nvidia-gb200-inference.conf
+++ b/nvidia-tuned/profiles/service/eks/nvidia-gb200-inference.conf
@@ -3,8 +3,6 @@ include=nvidia-gb200-performance
 summary=Optimized for inference workloads (AWS-compatible)
 
 [bootloader]
-# Isolate CPUs for inference processes, 2 per socket
-cmdline_isolcpus=isolcpus=${f:cpulist_invert:${f:calc_isolated_cores:2}}
 # Allocate hugepages for better memory access
 cmdline_hugepages=hugepagesz=2M hugepages=8192
 

--- a/nvidia-tuned/profiles/service/eks/nvidia-h100-inference.conf
+++ b/nvidia-tuned/profiles/service/eks/nvidia-h100-inference.conf
@@ -3,8 +3,6 @@ include=nvidia-h100-performance
 summary=Optimized for inference workloads (AWS-compatible)
 
 [bootloader]
-# Isolate CPUs for inference processes, 2 per socket
-cmdline_isolcpus=isolcpus=${f:cpulist_invert:${f:calc_isolated_cores:2}}
 # Allocate hugepages for better memory access
 cmdline_hugepages=hugepagesz=2M hugepages=8192
 


### PR DESCRIPTION
## Summary

- Removes `cmdline_isolcpus` from all inference profiles (os/common h100 + gb200, service/aks h100, service/eks h100 + gb200).
- Cleans up stale "Without cpu isolation due to tuned package version" summary text in debian/11 and ubuntu/22.04 os-specific gb200 profiles.
- Bumps `package_version` to `0.3.2`.

## Background

Closes #95. `isolcpus=0,1,48,49` on AKS H100 nodes was isolating the housekeeping cores (including CPU0, the default IRQ target) rather than workload cores. Under high-concurrency inference serving this starved network/softirq processing:

| Configuration | Throughput | TTFT p99 | Verdict |
|---|---|---|---|
| Full profile (with `isolcpus`) | 50,404 tok/s | 6,034 ms | FAIL |
| Same profile, `isolcpus` removed | 148,344 tok/s | 614 ms | PASS |
| Untuned stock AKS node | 146,452 tok/s | 547 ms | PASS |

Single-variable bisect from #95 confirmed `isolcpus` was the sole cause. The remaining profile settings (hugepages, iommu=pt, pci=realloc=off, init_on_alloc=0, vm.swappiness=1) are innocent.

## Test plan

- [ ] CI validate + dev build passes for `nvidia-tuned`
- [ ] `make test-package PACKAGE=nvidia-tuned` passes locally
- [ ] Verify no `isolcpus` in any tuned.conf: `grep -r isolcpus nvidia-tuned/`