### PR TITLE
docs: add GitHub Copilot instructions pointing at AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Copilot Instructions for NodeWright-Packages
+
+GitHub Copilot should follow this project's canonical coding-agent rules. Those
+rules (package layout, the config.json contract, shell/Python conventions, how
+packages are built and released, commit signing, and the pull request process)
+live in one place and are mirrored for every tool that reads this directory.
+
+Do not duplicate that content here. Read the canonical sources directly:
+
+- **[AGENTS.md](../AGENTS.md)** is the canonical agent guide; treat it as
+  authoritative for repository layout, package structure, and coding
+  conventions.
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** covers DCO sign-off, commit signing,
+  the AI-assisted contributions policy, and how to open a PR.
+- **[README.md](../README.md)** explains what a package is and how the pieces
+  fit together.
+
+When in doubt, prefer the existing patterns in the package you are editing over
+introducing new ones.


### PR DESCRIPTION
## What

Adds `.github/copilot-instructions.md` so GitHub Copilot picks up the project's canonical coding-agent rules.

## Why

We already maintain `AGENTS.md` for Claude/Codex/Cursor and just added an AI-assisted contributions policy to `CONTRIBUTING.md`. GitHub Copilot reads `.github/copilot-instructions.md` specifically; without it, Copilot ignores our conventions. This file carries no duplicated content: it points at `AGENTS.md`, `CONTRIBUTING.md`, and `README.md` as the single sources of truth.

Mirror of the same file being added to the operator repo. One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.