### PR TITLE
fix(bind-mount): require mount before kubelet startup

### DIFF
--- a/bind-mount/README.md
+++ b/bind-mount/README.md
@@ -17,7 +17,7 @@ spec:
     count: 1
   packages:
     bind-mount:
-      version: 0.1.0
+      version: 0.1.1
       image: ghcr.io/nvidia/nodewright-packages/bind-mount
       interrupt:
         type: reboot
@@ -48,6 +48,8 @@ closed rather than sharing or replacing it.
 - Uninstall disables and removes the persistent unit but deliberately does not unmount a live target. Recycle the node to complete rollback safely.
 - A root-only ownership receipt supports ConfigMap-less uninstall on operators older than v0.16.0 and preserves cleanup after an interrupted install on newer operators. The receipt is removed after `uninstall-check` confirms that no owned unit remains.
 - Uninstall of a package instance that never installed succeeds as a clean no-op, even when the uninstall runs without a ConfigMap. It only sweeps units carrying that exact Skyhook-resource/package-key owner marker and cannot remove another instance's unit.
-- The mount unit orders before `local-fs.target` and the kubelet units (`kubelet.service`, `snap.kubelet-eks.daemon.service`) so a rebooting node mounts the target before workloads start. Ordering is hygiene, not a success gate; the post-interrupt check is the gate.
+- The mount unit rechecks during boot that the source is itself a read-write mount point. This prevents an existing source directory on the root filesystem from being accepted when the source mount definition is missing or fails.
+- The mount unit is installed as a required dependency of `kubelet.service` and `snap.kubelet-eks.daemon.service`, and it orders before both. The lifecycle checks verify that both dependency links resolve to the owned mount unit. If the mount cannot start during boot, kubelet remains down instead of admitting workloads onto the unmounted target. The post-interrupt check remains the controlled-activation gate.
+- The kubelet dependency is a start-up gate, not a continuous runtime binding. An unexpected unmount after kubelet has started requires external invariant monitoring and immediate workload containment; consumers should alert whenever a Ready node no longer has the expected target mount.
 
 The apply and config checks validate the prepared unit before an interrupt. The post-interrupt check validates the active host mount. Consumers should use `runtimeRequired: true` and a bounded interruption budget.

--- a/bind-mount/RELEASE_NOTES.md
+++ b/bind-mount/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ scripts/gen-changelog.sh and must not be edited by hand after the initial
 package release.
 -->
 
+## 0.1.1
+
+Kubelet now requires successful bind-mount activation during boot. If the
+source filesystem is unavailable, the node remains NotReady instead of
+admitting workloads onto the unmounted target path.
+
+The generated unit also asserts that the source remains a read-write mount
+point, and lifecycle checks verify that both supported kubelet dependency links
+resolve to the owned mount unit.
+
 ## 0.1.0
 
 Initial release of a fail-closed, systemd-managed bind mount package.

--- a/bind-mount/config.json
+++ b/bind-mount/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "bind-mount",
-    "package_version": "0.1.0",
+    "package_version": "0.1.1",
     "expected_config_files": [
         "source",
         "target"

--- a/bind-mount/skyhook_dir/bind_mount.sh
+++ b/bind-mount/skyhook_dir/bind_mount.sh
@@ -281,8 +281,10 @@ target_is_empty_directory() {
         [[ -z "$(find "${TARGET}" -mindepth 1 -maxdepth 1 -print -quit)" ]]
 }
 
-# The kubelet units in Before= are ordering hygiene for Kubernetes hosts
-# (mount before workloads start on reboot); systemd ignores absent units.
+# RequiredBy= makes successful mount activation a kubelet start requirement on
+# Kubernetes hosts. Together with Before=, this fails closed when the source is
+# unavailable during boot: kubelet stays down instead of admitting workloads
+# onto an unmounted target. systemd tolerates the absent alternate unit name.
 render_unit() {
     local output="$1"
 
@@ -291,6 +293,8 @@ ${OWNER_MARKER}
 [Unit]
 Description=Bind ${SOURCE} at ${TARGET}
 RequiresMountsFor=${SOURCE}
+AssertPathIsMountPoint=${SOURCE}
+AssertPathIsReadWrite=${SOURCE}
 AssertDirectoryNotEmpty=!${TARGET}
 Before=local-fs.target kubelet.service snap.kubelet-eks.daemon.service
 
@@ -302,7 +306,26 @@ Options=bind
 
 [Install]
 WantedBy=local-fs.target
+RequiredBy=kubelet.service snap.kubelet-eks.daemon.service
 EOF
+}
+
+validate_kubelet_dependency_links() {
+    local kubelet_unit requires_link resolved
+
+    for kubelet_unit in kubelet.service snap.kubelet-eks.daemon.service; do
+        requires_link="${SYSTEMD_DIR}/${kubelet_unit}.requires/${UNIT_NAME}"
+        if [[ ! -L "${requires_link}" ]]; then
+            printf "required dependency link '%s' is missing or is not a symlink" "${requires_link}"
+            return 1
+        fi
+        resolved="$(readlink -f -- "${requires_link}" 2>/dev/null || true)"
+        if [[ "${resolved}" != "${UNIT_FILE}" ]]; then
+            printf "required dependency link '%s' resolves to '%s', expected '%s'" \
+                "${requires_link}" "${resolved:-<unresolved>}" "${UNIT_FILE}"
+            return 1
+        fi
+    done
 }
 
 write_state_file() {
@@ -545,6 +568,8 @@ check_no_fstab_owner() {
 }
 
 install_mount() {
+    local dependency_error
+
     load_desired_config
     validate_source_mount
     prepare_previous_state_reconciliation
@@ -596,7 +621,16 @@ install_mount() {
     require_exact_systemd_fragment "${UNIT_NAME}" "${UNIT_FILE}"
     [[ "${SYSTEMD_LOAD_STATE}" == "loaded" ]] || \
         fail "owned unit '${UNIT_NAME}' has load state '${SYSTEMD_LOAD_STATE}' after daemon-reload"
-    systemctl enable "${UNIT_NAME}"
+    if ! systemctl enable "${UNIT_NAME}"; then
+        systemctl disable "${UNIT_NAME}" || \
+            fail "enable failed for '${UNIT_NAME}' and its systemd side effects could not be rolled back"
+        fail "could not enable unit '${UNIT_NAME}'"
+    fi
+    if ! dependency_error="$(validate_kubelet_dependency_links)"; then
+        systemctl disable "${UNIT_NAME}" || \
+            fail "${dependency_error}; systemd side effects could not be rolled back"
+        fail "${dependency_error}"
+    fi
     if [[ -n "${TEMPORARY_FILE}" ]]; then
         rm -f -- "${TEMPORARY_FILE}"
         TEMPORARY_FILE=""
@@ -607,6 +641,8 @@ install_mount() {
 }
 
 prepared_check() {
+    local dependency_error
+
     load_desired_config
     validate_source_mount
     read_state || fail "state file '${STATE_FILE}' is missing"
@@ -620,6 +656,9 @@ prepared_check() {
     rm -f -- "${TEMPORARY_FILE}"
     TEMPORARY_FILE=""
     systemctl is-enabled --quiet "${UNIT_NAME}" || fail "unit '${UNIT_NAME}' is not enabled"
+    if ! dependency_error="$(validate_kubelet_dependency_links)"; then
+        fail "${dependency_error}"
+    fi
 
     if exact_mount_target "${TARGET}"; then
         same_bind_mount || fail "active target '${TARGET}' does not bind the desired source"

--- a/tests/integration/bind_mount/fakes/systemctl
+++ b/tests/integration/bind_mount/fakes/systemctl
@@ -33,11 +33,35 @@ case "${action}" in
         ;;
     enable)
         [[ "${FAKE_ENABLE_FAIL:-false}" != "true" ]] || exit 1
+        unit_file="/etc/systemd/system/${unit}"
+        required_by_units="$(
+            [[ "${FAKE_REQUIRED_BY_PARSE_FAIL:-false}" != "true" ]] || exit 1
+            awk '
+                $0 == "[Install]" { in_install = 1; next }
+                /^\[/ { in_install = 0 }
+                in_install && /^RequiredBy=/ {
+                    sub(/^RequiredBy=/, "")
+                    for (i = 1; i <= NF; i++) print $i
+                }
+            ' "${unit_file}"
+        )"
+        while IFS= read -r required_by; do
+            [[ -n "${required_by}" ]] || continue
+            [[ "${FAKE_REQUIRED_BY_LINK_FAIL:-}" != "${required_by}" ]] || exit 1
+            [[ "${FAKE_REQUIRED_BY_LINK_SKIP:-}" != "${required_by}" ]] || continue
+            requires_dir="/etc/systemd/system/${required_by}.requires"
+            mkdir -p "${requires_dir}"
+            ln -sfn "../${unit}" "${requires_dir}/${unit}"
+        done <<<"${required_by_units}"
         touch "${STATE_DIR}/enabled-${unit}"
         ;;
     disable)
         [[ "${FAKE_DISABLE_FAIL:-false}" != "true" ]] || exit 1
         rm -f "${STATE_DIR}/enabled-${unit}"
+        for requires_dir in /etc/systemd/system/*.requires; do
+            [[ -d "${requires_dir}" ]] || continue
+            rm -f "${requires_dir}/${unit}"
+        done
         ;;
     show)
         [[ "${FAKE_SHOW_FAIL:-false}" != "true" ]] || exit 1

--- a/tests/integration/bind_mount/test_lifecycle.py
+++ b/tests/integration/bind_mount/test_lifecycle.py
@@ -29,12 +29,14 @@ SCRIPT = "/skyhook-package/skyhook_dir/bind_mount.sh"
 SOURCE = "/mnt/k8s-disks/0"
 TARGET = "/mnt/data"
 SECOND_TARGET = "/mnt/log"
+UNIT_NAME = "mnt-data.mount"
 UNIT_FILE = "/etc/systemd/system/mnt-data.mount"
+KUBELET_UNITS = ("kubelet.service", "snap.kubelet-eks.daemon.service")
 SECOND_UNIT_FILE = "/etc/systemd/system/mnt-log.mount"
 SKYHOOK_NAME = "local-data-bind"
 SKYHOOK_UID = "11111111-2222-3333-4444-555555555555"
 PACKAGE_KEY = "bind-data"
-PACKAGE_VERSION = "0.1.0"
+PACKAGE_VERSION = "0.1.1"
 STATE_ROOT = "/var/lib/nodewright-packages/bind-mount"
 FAKES = Path(__file__).parent / "fakes"
 EXTRA_FILES = [(path, f"test-bin/{path.name}") for path in FAKES.iterdir()]
@@ -171,8 +173,16 @@ def test_install_prepares_owned_unit_without_activating_it(base_image):
         assert "# Managed by NodeWright package bind-mount" in unit
         assert f"What={SOURCE}" in unit
         assert f"Where={TARGET}" in unit
+        assert f"AssertPathIsMountPoint={SOURCE}" in unit
+        assert f"AssertPathIsReadWrite={SOURCE}" in unit
         assert f"AssertDirectoryNotEmpty=!{TARGET}" in unit
         assert "Before=local-fs.target kubelet.service snap.kubelet-eks.daemon.service" in unit
+        assert "RequiredBy=kubelet.service snap.kubelet-eks.daemon.service" in unit
+        for kubelet_unit in KUBELET_UNITS:
+            requires_link = f"/etc/systemd/system/{kubelet_unit}.requires/{UNIT_NAME}"
+            resolved = runner.container.exec_run(["readlink", "-f", requires_link])
+            assert resolved.exit_code == 0, resolved.output.decode("utf-8", errors="replace")
+            assert resolved.output.decode().strip() == UNIT_FILE
         assert_no_staging_directories(runner)
     finally:
         runner.cleanup()
@@ -187,6 +197,47 @@ def test_install_and_prepared_check_are_idempotent(base_image):
         exit_code, output = exec_mode(runner, "prepared-check")
         assert exit_code == 0, output
         assert "Prepared mount definition" in output
+    finally:
+        runner.cleanup()
+
+
+def test_prepared_check_rejects_missing_kubelet_dependency_link(base_image):
+    runner, result = start_runner(base_image)
+    try:
+        assert_exit_code(result, 0)
+        requires_link = (
+            f"/etc/systemd/system/{KUBELET_UNITS[0]}.requires/{UNIT_NAME}"
+        )
+        removed = runner.container.exec_run(["rm", "-f", requires_link])
+        assert removed.exit_code == 0, removed.output.decode(
+            "utf-8", errors="replace"
+        )
+
+        exit_code, output = exec_mode(runner, "prepared-check")
+        assert exit_code == 1
+        assert f"required dependency link '{requires_link}' is missing" in output
+    finally:
+        runner.cleanup()
+
+
+def test_prepared_check_rejects_misdirected_kubelet_dependency_link(base_image):
+    runner, result = start_runner(base_image)
+    try:
+        assert_exit_code(result, 0)
+        requires_link = (
+            f"/etc/systemd/system/{KUBELET_UNITS[1]}.requires/{UNIT_NAME}"
+        )
+        replaced = runner.container.exec_run(
+            ["ln", "-sfn", "/tmp/foreign.mount", requires_link]
+        )
+        assert replaced.exit_code == 0, replaced.output.decode(
+            "utf-8", errors="replace"
+        )
+
+        exit_code, output = exec_mode(runner, "prepared-check")
+        assert exit_code == 1
+        assert f"required dependency link '{requires_link}' resolves" in output
+        assert "expected '/etc/systemd/system/mnt-data.mount'" in output
     finally:
         runner.cleanup()
 
@@ -904,6 +955,61 @@ def test_failed_enable_retains_cleanup_receipt(base_image):
         assert not runner.file_exists(UNIT_FILE)
         assert not runner.file_exists(STATE_FILE)
         assert runner.file_exists(UNINSTALL_STATE_FILE)
+    finally:
+        runner.cleanup()
+
+
+def test_failed_dependency_parser_does_not_mark_unit_enabled(base_image):
+    runner, result = start_runner(
+        base_image, env={"FAKE_REQUIRED_BY_PARSE_FAIL": "true"}
+    )
+    try:
+        assert_exit_code(result, 1)
+        assert runner.file_exists(UNIT_FILE)
+        assert runner.file_exists(STATE_FILE)
+        assert not runner.file_exists("/tmp/fake-systemctl/enabled-mnt-data.mount")
+        for kubelet_unit in KUBELET_UNITS:
+            requires_link = (
+                f"/etc/systemd/system/{kubelet_unit}.requires/{UNIT_NAME}"
+            )
+            assert not runner.file_exists(requires_link)
+    finally:
+        runner.cleanup()
+
+
+def test_failed_dependency_link_does_not_mark_unit_enabled(base_image):
+    runner, result = start_runner(
+        base_image, env={"FAKE_REQUIRED_BY_LINK_FAIL": KUBELET_UNITS[1]}
+    )
+    try:
+        assert_exit_code(result, 1)
+        assert runner.file_exists(UNIT_FILE)
+        assert runner.file_exists(STATE_FILE)
+        assert not runner.file_exists("/tmp/fake-systemctl/enabled-mnt-data.mount")
+        for kubelet_unit in KUBELET_UNITS:
+            requires_link = (
+                f"/etc/systemd/system/{kubelet_unit}.requires/{UNIT_NAME}"
+            )
+            assert not runner.file_exists(requires_link)
+    finally:
+        runner.cleanup()
+
+
+def test_install_rejects_successful_enable_with_missing_dependency_link(base_image):
+    runner, result = start_runner(
+        base_image, env={"FAKE_REQUIRED_BY_LINK_SKIP": KUBELET_UNITS[1]}
+    )
+    try:
+        assert_exit_code(result, 1)
+        assert_output_contains(result.stdout, "required dependency link")
+        assert_output_contains(result.stdout, "is missing or is not a symlink")
+        assert not runner.file_exists("/tmp/fake-systemctl/enabled-mnt-data.mount")
+        assert runner.file_exists(STATE_FILE)
+        for kubelet_unit in KUBELET_UNITS:
+            requires_link = (
+                f"/etc/systemd/system/{kubelet_unit}.requires/{UNIT_NAME}"
+            )
+            assert not runner.file_exists(requires_link)
     finally:
         runner.cleanup()
 


### PR DESCRIPTION
## Problem

`bind-mount/0.1.0` orders the generated mount unit before kubelet but does not make successful mount activation a kubelet startup requirement. On a later reboot, a missing source filesystem or failed mount can therefore allow kubelet to start with the target path backed by root storage.

## Fix

- Install the generated mount unit as a required dependency of both supported kubelet unit names while retaining explicit startup ordering.
- Bump `bind-mount` to `0.1.1` and document the fail-closed behavior.
- Assert the generated dependency in the lifecycle suite.

## Validation

- `make test-package PACKAGE=bind-mount` (86 passed on Ubuntu 22.04 and 24.04)
- `make validate-standalone PACKAGE=bind-mount`
- `make license-check`
- `shellcheck bind-mount/skyhook_dir/bind_mount.sh`