### PR TITLE
ci: auto-assign PR author on open

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assigns the author to their own PR on open, so every PR has a clear owner.
+# Contributors can still hand a PR off with /assign (see assign.yaml).
+#
+# pull_request_target runs in the base-repo context with a token that can write,
+# which is required to assign fork PRs. This is safe here: the job never checks
+# out or executes PR code, it only calls the assignee API with the event payload.
+
+name: Auto-Assign PR Author
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  assign-author:
+    name: Assign author to their PR
+    runs-on: ubuntu-latest
+    permissions:
+      # Assigning goes through the Issues API (issues.addAssignees), so issues
+      # write is all this job needs.
+      issues: write
+    timeout-minutes: 5
+    steps:
+      - name: Assign the author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const common = { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number };
+
+            // Skip bots (Dependabot, etc.): they are not assignable and it would
+            // just be noise.
+            if (pr.user.type === 'Bot') {
+              core.info(`Skipping bot author ${author}`);
+              return;
+            }
+
+            // Re-read live assignees instead of trusting the opened-event
+            // snapshot: a manual /assign or UI assignment made between open and
+            // this run should be respected rather than overwritten.
+            const { data: current } = await github.rest.issues.get(common);
+            if ((current.assignees || []).length > 0) {
+              core.info('PR already has an assignee; leaving as-is');
+              return;
+            }
+
+            try {
+              const { data: updated } = await github.rest.issues.addAssignees({ ...common, assignees: [author] });
+              // addAssignees silently ignores non-assignable users; report if so.
+              if (!updated.assignees.some(a => a.login === author)) {
+                core.warning(`Could not assign ${author} (not assignable in this repo)`);
+              } else {
+                core.info(`Assigned ${author} to PR #${pr.number}`);
+              }
+            } catch (err) {
+              core.warning(`Failed to assign ${author} to PR #${pr.number}: ${err.message}`);
+            }


### PR DESCRIPTION
## What

Adds an `Auto-Assign PR Author` workflow that assigns the author to their own PR when it is opened, so every PR has a clear owner from the start.

## Why

Complements the existing self-service `assign.yaml` (`/assign`): rather than requiring a manual claim, the author is set automatically on open. They (or a maintainer) can still reassign with `/assign @user` or `/unassign`. Mirror of the operator repo.

## Design notes

- **Skips bots** (Dependabot, etc.) — not assignable, and it would just be noise.
- **Respects an existing assignee** set at open time.
- **Reports non-assignable authors**: `addAssignees` silently drops users without repo access, so the workflow logs a warning.
- Uses `pull_request_target` so it also works for fork PRs. Safe: the job never checks out or executes PR code — it only calls the assignee API with the event payload.
- `github-script` pinned to the same SHA used by the other workflows.