### PR TITLE
docs(ci): correct auto-assign comment (/assign is issues-only)

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 # Assigns the author to their own PR on open, so every PR has a clear owner.
-# Contributors can still hand a PR off with /assign (see assign.yaml).
+# A maintainer can reassign later from the GitHub UI. (The /assign comment
+# command in assign.yaml is for issues, not PRs.)
 #
 # pull_request_target runs in the base-repo context with a token that can write,
 # which is required to assign fork PRs. This is safe here: the job never checks


### PR DESCRIPTION
## What

Corrects the header comment in `auto-assign-author.yaml`. It claimed contributors can hand a PR off with `/assign`, but `assign.yaml` only runs on **issue** comments — it excludes PRs via `!github.event.issue.pull_request`. The comment now says PR reassignment is done from the GitHub UI.

No behavior change; comment-only.

## Background

This PR originally proposed sharing a concurrency group between `assign.yaml` and `auto-assign-author.yaml`. That was based on a false premise (that `/assign` runs on PRs): since `/assign` is issue-only and auto-assign is PR-only, the two never operate on the same target and can't race, so the coupling was dropped. The mirror change on the operator repo (NVIDIA/nodewright#328) likewise reverted the coupling.