### PR TITLE
fix(ci): grant pull-requests: write to auto-assign author

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -41,9 +41,11 @@ jobs:
     name: Assign author to their PR
     runs-on: ubuntu-latest
     permissions:
-      # Assigning goes through the Issues API (issues.addAssignees), so issues
-      # write is all this job needs.
+      # Assigning a PR needs pull-requests: write — the assignee endpoint
+      # returns 403 "Resource not accessible by integration" with issues:write
+      # alone. issues: write covers the pre-assignment issues.get read.
       issues: write
+      pull-requests: write
     timeout-minutes: 5
     steps:
       - name: Assign the author


### PR DESCRIPTION
## What

Adds `pull-requests: write` to the `auto-assign-author` job's permissions.

## Why

Assigning the author to a PR fails at runtime with a **403** (`Resource not accessible by integration`) when the token has `issues: write` only. Despite `issues.addAssignees` being nominally an Issues-API method, **assigning a pull request requires `pull-requests: write`**. The job caught the error and logged a warning, so it exited green while silently never assigning.

Observed on the operator repo (NVIDIA/nodewright PR #351 run); this repo's workflow is identical and has the same latent bug.

## Fix

Grant `pull-requests: write` alongside `issues: write` (the latter still covers the pre-assignment `issues.get` read). Mirror of NVIDIA/nodewright#352.