### PR TITLE
docs(general): add governance, maintainers, and security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,21 @@
 # Global catch-all
-* @lockwobr @mskalka @ayuskauskas @rice-riley
+* @lockwobr @ayuskauskas @rice-riley
 
 # Package directories
-kdump/             @lockwobr @mskalka @ayuskauskas @rice-riley
-nvidia-setup/      @lockwobr @mskalka @ayuskauskas @rice-riley
-nvidia-tuned/      @lockwobr @mskalka @ayuskauskas @rice-riley
-nvidia-tuning-gke/ @lockwobr @mskalka @ayuskauskas @rice-riley
-tuned/             @lockwobr @mskalka @ayuskauskas @rice-riley
-tuning/            @lockwobr @mskalka @ayuskauskas @rice-riley
-shellscript/       @lockwobr @mskalka @ayuskauskas @rice-riley
-installer/         @lockwobr @mskalka @ayuskauskas @rice-riley
+kdump/             @lockwobr @ayuskauskas @rice-riley
+nvidia-setup/      @lockwobr @ayuskauskas @rice-riley
+nvidia-tuned/      @lockwobr @ayuskauskas @rice-riley
+nvidia-tuning-gke/ @lockwobr @ayuskauskas @rice-riley
+tuned/             @lockwobr @ayuskauskas @rice-riley
+tuning/            @lockwobr @ayuskauskas @rice-riley
+shellscript/       @lockwobr @ayuskauskas @rice-riley
+copy-fail/         @lockwobr @ayuskauskas @rice-riley
+bind-mount/        @lockwobr @ayuskauskas @rice-riley
 
 # Build/ops
-.github/           @lockwobr @mskalka @ayuskauskas @rice-riley
-scripts/           @lockwobr @mskalka @ayuskauskas @rice-riley
-makefile           @lockwobr @mskalka @ayuskauskas @rice-riley
+.github/           @lockwobr @ayuskauskas @rice-riley
+scripts/           @lockwobr @ayuskauskas @rice-riley
+makefile           @lockwobr @ayuskauskas @rice-riley
 
 # Tests
-tests/             @lockwobr @mskalka @ayuskauskas @rice-riley
+tests/             @lockwobr @ayuskauskas @rice-riley

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,3 @@
-<!--
-  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  SPDX-License-Identifier: Apache-2.0
--->
-
 # Contributor Covenant Code of Conduct
 
 ## Overview
@@ -15,75 +10,84 @@ Community | Developers | Project Leads
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate
-to the circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident. Further details of specific enforcement policies
-may be posted separately. 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at GitHub_Conduct@nvidia.com. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+The response timeline and what falls outside the scope of a conduct report are documented in [CONTRIBUTING.md](CONTRIBUTING.md#community-standards).
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,16 @@
 
 Want to contribute to NodeWright-Packages?
 
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating you are expected to uphold it. Report unacceptable behavior to GitHub_Conduct@nvidia.com. See [Community standards](#community-standards) for how reports are handled.
+
+## Governance
+
+Maintainers, decision-making, and the process for becoming a maintainer are documented in [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md). Path-level review ownership is in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+## Developer Certificate of Origin (DCO)
+
 The sign-off is a simple line at the end of the explanation for the patch. Your
 signature certifies that you wrote the patch or otherwise have the right to pass
 it on as an open-source patch. The rules are pretty simple: if you can certify
@@ -96,3 +106,28 @@ This wraps [`google/addlicense`](https://github.com/google/addlicense) (run via 
 so a local Go toolchain is required); it is idempotent and never duplicates a header.
 Run `make license-check` to verify without modifying files; CI runs the same check on
 every PR.
+
+## Community standards
+
+We enforce the [Code of Conduct](CODE_OF_CONDUCT.md) in every project space: issues, pull requests, discussions, and any venue where someone is representing NodeWright Packages.
+
+### Reporting
+
+Send reports to GitHub_Conduct@nvidia.com. Include what happened, where, when, and links if the incident is public. You do not need to be the target of the behavior to report it.
+
+### Response timeline
+
+- **Acknowledgement within 3 business days.** You get a confirmation that the report was received and who is handling it.
+- **Resolution within 14 business days** for most reports. If an investigation needs longer, we tell you that before day 14 and give an updated estimate.
+- **Immediate action** for ongoing harassment, threats, or doxxing, ahead of the full investigation.
+
+Reporter identity is shared only with the people investigating. Outcomes follow the [Enforcement Guidelines](CODE_OF_CONDUCT.md#enforcement-guidelines) ladder: correction, warning, temporary ban, permanent ban.
+
+### Out of scope
+
+The following are handled elsewhere, not through a conduct report:
+
+- **Security vulnerabilities**: see [SECURITY.md](SECURITY.md). Do not file a public issue.
+- **Technical disagreements**, including rejected pull requests and design decisions you disagree with. Escalate through the process in [GOVERNANCE.md](GOVERNANCE.md#decision-making).
+- **Conduct in venues unrelated to NodeWright**, unless it creates a credible safety risk for someone in this community.
+- **NVIDIA employment or HR matters**, which go through NVIDIA's internal channels.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,82 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NodeWright Packages Project Governance
+
+This document describes how the NodeWright Packages project is governed: the roles people hold, how decisions get made, and how maintainers join and leave. It is intentionally lightweight and will grow with the project. For the current roster and maintainer responsibilities, see [MAINTAINERS.md](MAINTAINERS.md).
+
+## Project Scope
+
+This repository holds the first-party packages that [NodeWright](https://github.com/NVIDIA/nodewright) applies to cluster nodes. Each package is a container image with lifecycle steps (uninstall, upgrade, apply, config, interrupt, post-interrupt) that the NodeWright agent executes against the host.
+
+In scope: the packages in this repository, their configuration schemas, the shared build tooling, and the tests that exercise them.
+
+Out of scope: the NodeWright operator, agent, CRDs, and CLI, which live in [NVIDIA/nodewright](https://github.com/NVIDIA/nodewright). Third-party packages built by other teams are owned by their authors and are not governed here.
+
+## Roles
+
+NodeWright Packages uses three roles. Code ownership maps directly to [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+### Contributors
+
+Anyone who opens an issue, pull request, or discussion. Contributors follow the [Code of Conduct](CODE_OF_CONDUCT.md) and sign off their commits under the DCO (see [CONTRIBUTING.md](CONTRIBUTING.md)). No special access is required to contribute.
+
+### Code Owners
+
+Trusted contributors who review and approve pull requests for the paths they own. Code ownership is declared per path in [`.github/CODEOWNERS`](.github/CODEOWNERS), which GitHub uses to request reviews automatically. Code owners keep their areas healthy and mentor contributors.
+
+### Maintainers
+
+Maintainers have merge rights, make and ratify project decisions, manage releases, and own this governance process, including adding and removing maintainers. Maintainers are also code owners. The current roster is in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Areas of Ownership
+
+Path-level ownership is authoritative in [`.github/CODEOWNERS`](.github/CODEOWNERS). At a high level the project is organized into:
+
+- **Packages**: one directory per package (`bind-mount/`, `copy-fail/`, `kdump/`, `nvidia-setup/`, `nvidia-tuned/`, `nvidia-tuning-gke/`, `shellscript/`, `tuned/`, `tuning/`), each with its own `config.json`, README, and version.
+- **Shared tooling** (`scripts/`, `makefile`): build, packaging, and release automation common to every package.
+- **Tests** (`tests/`): the suites that validate package behavior.
+- **CI** (`.github/`): workflows, issue and pull request templates, and release plumbing.
+- **Documentation** (`PACKAGE_LIFECYCLE.md`, `DEVELOPER.md`, root project docs).
+
+Maintainers hold cross-cutting responsibility across all areas.
+
+## Decision-Making
+
+NodeWright Packages decides by **lazy consensus**: a proposal (pull request, issue, or discussion) is accepted if no maintainer raises a blocking objection within a reasonable review window, at least five business days for non-trivial changes. Most day-to-day changes are merged through normal code-owner review under [`.github/CODEOWNERS`](.github/CODEOWNERS) and the process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+When consensus is not reached:
+
+- **Majority vote.** Any maintainer may call a vote. A proposal passes on a simple majority of non-emeritus maintainers; quorum is a simple majority of that same group.
+- **Blocking objection (veto).** A maintainer may block a change by stating a concrete technical rationale and an actionable path to resolution. A blocked change proceeds only if a two-thirds supermajority of non-emeritus maintainers votes to override.
+- **Supermajority decisions.** Adding or removing a maintainer, and changes to this document, require a two-thirds supermajority of non-emeritus maintainers.
+
+Changes that alter a package's config schema, its lifecycle step contract, or its interrupt behavior always require an explicit approval from at least one maintainer who did not author the change, regardless of the review window. These surfaces are consumed by clusters running the operator, and a silent break there reaches production nodes.
+
+## Tie-Breaking
+
+If a vote is tied, the **lead maintainer** has the casting vote. The lead maintainer is designated by the maintainer team and recorded in [MAINTAINERS.md](MAINTAINERS.md); the role exists to break deadlocks and carries no additional day-to-day authority. If the lead maintainer is the subject of, or is recused from, a decision, the remaining maintainers designate an acting lead for that decision.
+
+## Adding and Removing Maintainers
+
+### Adding
+
+Maintainers are added on merit. An existing maintainer nominates a candidate based on sustained contributions, review quality, and domain expertise. The nominee is added when a two-thirds supermajority of non-emeritus maintainers approves.
+
+### Removing and stepping down
+
+A maintainer may step down at any time by opening a pull request that moves them to emeritus. A maintainer may also be removed by a two-thirds supermajority of non-emeritus maintainers, for sustained inactivity (see [Emeritus](#emeritus)) or for conduct that violates the [Code of Conduct](CODE_OF_CONDUCT.md). Removal for cause follows the Code of Conduct enforcement process.
+
+## Emeritus
+
+A maintainer is considered **inactive** after six months with no substantive contribution, review, or governance participation. Inactive maintainers are moved to the Emeritus list in [MAINTAINERS.md](MAINTAINERS.md) either voluntarily, or involuntarily by the same two-thirds supermajority of non-emeritus maintainers required for removal. Moving to emeritus removes merge rights and excludes the maintainer from quorum and vote counts. Emeritus maintainers are welcomed back through the normal onboarding process when they return to active participation.
+
+## Deprecation and End-of-Life
+
+Packages are versioned independently and follow semver, as described in the Versioning section of the [README](README.md#versioning). Removing a package, or making a breaking change to its config schema or lifecycle contract, requires a deprecation notice in `CHANGELOG.md` and a migration path in the package's README before the removal ships. A package that no longer has a maintainer is marked deprecated rather than left to rot silently.
+
+## Changing This Document
+
+Amendments follow the supermajority rule above: a pull request plus approval from a two-thirds supermajority of non-emeritus maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,43 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Maintainers
+
+This document lists the maintainers of the NodeWright Packages project. Project decision-making, tie-breaking, and the maintainer add/remove and emeritus processes are documented in [GOVERNANCE.md](GOVERNANCE.md). Path-level review ownership is defined in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
+## Current Maintainers
+
+Lead maintainer first, then sorted by GitHub handle.
+
+| GitHub | Name |
+|---|---|
+| [@lockwobr](https://github.com/lockwobr) | Brian Lockwood (**lead maintainer**) |
+| [@ayuskauskas](https://github.com/ayuskauskas) | Alex Yuskauskas |
+| [@rice-riley](https://github.com/rice-riley) | Riley Rice |
+
+The lead maintainer holds the casting vote on tied maintainer votes and has no additional day-to-day authority. See [Tie-Breaking](GOVERNANCE.md#tie-breaking).
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and discussions
+- Ensuring code quality and test coverage
+- Making release decisions for the independently versioned packages
+- Keeping package READMEs and config schemas accurate as behavior changes
+- Upholding the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Changes to This List
+
+Maintainers are added and removed through the process in [GOVERNANCE.md](GOVERNANCE.md#adding-and-removing-maintainers). A change lands in this file and in [`.github/CODEOWNERS`](.github/CODEOWNERS) in the same pull request.
+
+## Emeritus Maintainers
+
+Maintainers who are no longer actively maintaining the project. A maintainer moves here on request, or involuntarily after six months of inactivity by a two-thirds supermajority of non-emeritus maintainers. Inactivity alone does not move anyone automatically; the vote is required. Emeritus maintainers are welcomed back through the normal onboarding process. See [Emeritus](GOVERNANCE.md#emeritus).
+
+| GitHub | Name |
+|---|---|
+| [@mskalka](https://github.com/mskalka) | Michael Skalka |

--- a/README.md
+++ b/README.md
@@ -294,7 +294,14 @@ This validation step is crucial as the agent uses JSON schema validation to ensu
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on contributing to this repository.
+- Start here: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+
+## Governance & Maintainers
+
+- Governance: [GOVERNANCE.md](./GOVERNANCE.md) - roles, how decisions get made, how maintainers join and leave
+- Maintainers: [MAINTAINERS.md](./MAINTAINERS.md) - current roster
+- Review ownership: [`.github/CODEOWNERS`](./.github/CODEOWNERS)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,79 @@ To report a potential security vulnerability in any NVIDIA product:
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
 
+## Coordinated Disclosure
+
+PSIRT owns triage, severity assessment, and the disclosure date for reports filed through the channels above. What that means in this repository, while a report is under embargo:
+
+- Maintainers will not discuss the report in public issues, pull requests, or discussions.
+- A fix will not be merged with a commit message, pull request description, or test name that reveals the vulnerability ahead of the coordinated date.
+- No package version will be tagged or announced in a way that advertises the issue before PSIRT publishes.
+- The patched package release and the advisory ship together on the coordinated date, and the `CHANGELOG.md` entry links to the advisory.
+- Reporters who ask to remain anonymous are credited as "an anonymous reporter" rather than by name.
+
 ## NVIDIA Product Security
 
 For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security
+
+## Supported Versions
+
+Each package in this repository is versioned and released independently, following [Semantic Versioning](https://semver.org/), and tagged as `{package}/{version}` (for example `shellscript/1.1.1`). Security fixes are released against the latest minor of the affected package.
+
+| Package | Image | Supported |
+|---|---|---|
+| `shellscript/` | `ghcr.io/nvidia/skyhook-packages/shellscript` | Latest minor |
+| `tuning/` | `ghcr.io/nvidia/skyhook-packages/tuning` | Latest minor |
+| `tuned/` | `ghcr.io/nvidia/skyhook-packages/tuned` | Latest minor |
+| `kdump/` | `ghcr.io/nvidia/skyhook-packages/kdump` | Latest minor |
+| `nvidia-setup/` | `ghcr.io/nvidia/skyhook-packages/nvidia-setup` | Latest minor |
+| `nvidia-tuned/` | `ghcr.io/nvidia/skyhook-packages/nvidia-tuned` | Latest minor |
+| `nvidia-tuning-gke/` | `ghcr.io/nvidia/skyhook-packages/nvidia-tuning-gke` | Latest minor |
+| `copy-fail/` | `ghcr.io/nvidia/skyhook-packages/copy-fail` | Latest minor |
+| `bind-mount/` | `ghcr.io/nvidia/skyhook-packages/bind-mount` | Latest minor |
+
+Older minors are not patched. If you pin a package version in a NodeWright custom resource, upgrade the pin to pick up a security fix. Published versions are on the [releases page](https://github.com/NVIDIA/nodewright-packages/releases).
+
+These packages run **on the host, as root, through the NodeWright agent**. A vulnerability in a package step is a host-level issue, not a container-scoped one. Treat reports here with that in mind.
+
+The operator and agent that execute these packages are versioned separately and have their own policy; see [NVIDIA/nodewright](https://github.com/NVIDIA/nodewright/blob/main/SECURITY.md).
+
+## Verifying Release Artifacts
+
+Every published package image is signed with [Sigstore cosign](https://docs.sigstore.dev/) in keyless mode and carries [SLSA v1 build provenance](https://slsa.dev/). The build workflow verifies its own signature and attestation before finishing, pinning the signer to an exact tag with no wildcard.
+
+Verify a package image before you run it:
+
+Verify by digest, not by tag. A tag can be repointed between the moment you verify it and the moment you pull it; a digest cannot. This is also what the build workflow itself does.
+
+```bash
+REPO=ghcr.io/nvidia/skyhook-packages/<package>
+ISSUER=https://token.actions.githubusercontent.com
+IDENTITY="https://github.com/NVIDIA/nodewright-packages/.github/workflows/build_container.yaml@refs/tags/<package>/<version>"
+
+# Resolve the tag to an immutable digest once, then use it everywhere below
+DIGEST=$(crane digest "$REPO:<version>")
+IMAGE="$REPO@$DIGEST"
+
+# Keyless signature
+cosign verify --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER" "$IMAGE"
+
+# SLSA v1 build provenance
+cosign verify-attestation --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER" \
+  --type https://slsa.dev/provenance/v1 "$IMAGE"
+```
+
+Reference that same `$IMAGE` digest in the package `image` field of your NodeWright custom resource, so the artifact you verified is the artifact that runs.
+
+Without `crane`, use:
+
+```bash
+DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$REPO:<version>")
+```
+
+Take the top-level manifest digest, which is what the signature and attestation are bound to. Do not substitute one of the per-platform digests listed under `Manifests:` in the plain `docker buildx imagetools inspect` output; those are children of the index and will not verify.
+
+The certificate identity is the exact workflow and tag that built the image, so substitute the package and version you are verifying. Images published before the Skyhook to NodeWright repository rename carry a `NVIDIA/skyhook-packages` identity.
+
+A verification failure on a published image is itself a security report. Route it through the channels above.


### PR DESCRIPTION
## What

Adds the community and governance files the NVIDIA OSS-Template README prescribes but does not ship, and fills gaps found in an open source health review.

| File | Change |
|---|---|
| `GOVERNANCE.md` | New. Roles, per-package ownership, decision-making, tie-breaking, maintainer add/remove, emeritus, deprecation policy. |
| `MAINTAINERS.md` | New. Current roster and emeritus list. |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 1.4 to 2.1, same `GitHub_Conduct@nvidia.com` contact. |
| `CONTRIBUTING.md` | Adds Code of Conduct, Governance, and Community standards sections. Labels the previously unheaded DCO block. |
| `SECURITY.md` | Adds supported versions, coordinated disclosure, and artifact verification. NVIDIA PSIRT block untouched. |
| `README.md` | Links the Code of Conduct and the new governance docs. |
| `.github/CODEOWNERS` | Drops `@mskalka`, now recorded as emeritus. |

## Why these specifics

**Contributor Covenant 2.1, not 1.4 or 3.0.** 1.4 has no enforcement ladder. 3.0 ships with `[NOTE: ...]` placeholders you must fill in yourself and is licensed CC BY-SA 4.0, a ShareAlike term, in an otherwise Apache-2.0 repo. 2.1 is the finished document with the four-rung Community Impact ladder, and matches what [NVIDIA/aicr](https://github.com/NVIDIA/aicr/issues/1420) adopted.

**`SECURITY.md` additions are additive only.** 296 insertions across the PR, and the NVIDIA PSIRT template block is byte-identical to `main`. The new Coordinated Disclosure section deliberately does not restate the PSIRT contact points, policy link, or acknowledgement language already in the template; it covers only what maintainers of this repo do while a report is under embargo.

**Verification commands are real.** The cosign snippet mirrors what `.github/workflows/build_container.yaml` already runs against its own output, including the exact-tag certificate identity. No SBOM is claimed, because that workflow attaches SLSA provenance but does not generate one.

**Host-level blast radius is called out.** These packages run on the host as root through the NodeWright agent, so a vulnerability in a package step is not container-scoped. That was not written down anywhere.

**Nothing promises external maintainer eligibility.** Whether contributors outside NVIDIA can become maintainers is an open question, so `GOVERNANCE.md` documents the nomination and supermajority mechanism without claiming who is eligible. That can be added once the answer is known.

## Needs confirmation before merge

1. `SECURITY.md` says older minors are not patched. Confirm that matches actual practice.
2. The supported-versions table lists eight packages from the README. `.github/CODEOWNERS` also references `nvidia-tuned/` and `installer/`, which the README does not list as available packages. One of the two lists is stale.
3. `@lockwobr` is recorded as lead maintainer for tie-breaking.

## Verification

- All internal links and anchors resolve.
- `SECURITY.md`: 56 additions, 0 deletions; every original line present verbatim.
