### PR TITLE
fix(nvidia-tuned): restart tuned after changing reapply_sysctl

### DIFF
--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,26 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.5.1
+
+Fixes profile `[sysctl]` values being silently overwritten by `/etc/sysctl.d`.
+
+- `prepare_nvidia_profiles.sh` now restarts tuned after it changes
+  `/etc/tuned/tuned-main.conf`. tuned reads that file only when the daemon starts, and
+  `tuned-adm profile` does not re-read it, so the `reapply_sysctl = 0` written during the
+  config stage never reached the daemon that `install_tuned.sh` had already started. The
+  daemon kept `reapply_sysctl = 1` and re-applied `/etc/sysctl.d` after activating the
+  profile, overwriting the profile's `[sysctl]` values (tuned writes the `/etc/sysctl.d`
+  value even for options the profile owns; it only logs `Overriding sysctl parameter`).
+  The restart is skipped when the file is unchanged, so re-runs do not thrash tuned.
+- The `reapply_sysctl` rewrite now matches any value rather than only a bare `1`. A line
+  such as `reapply_sysctl = 1 # note` or `reapply_sysctl = 2` matched the guard but not
+  the old substitution, which left the setting on while reporting success.
+
+This mainly affects the `oci` service on GB300, where the node image disables IPv6 via
+`/etc/sysctl.d`: the profile's `net.ipv6.conf.*.disable_ipv6 = 0` did not survive, RDMA
+VFs came up with no routable GID, and `config-check` failed.
+
 ## 0.5.0
 
 Adds the `gb300` accelerator and the `oci` service.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.5.0",
+    "package_version": "0.5.1",
     "expected_config_files": ["accelerator"],
     "modes": {
         "uninstall": [

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
@@ -238,9 +238,14 @@ write_tuned_profile() {
 # settings take precedence over /etc/sysctl.d (e.g. cloud_customizations.conf).
 set_reapply_sysctl_off() {
     local tuned_main="/etc/tuned/tuned-main.conf"
+    local before=""
+    [[ -f "$tuned_main" ]] && before="$(cat "$tuned_main")"
+
     if [ -f "$tuned_main" ]; then
-        if grep -q '^[[:space:]]*reapply_sysctl[[:space:]]*=' "$tuned_main"; then
-            sed -i 's/^[[:space:]]*reapply_sysctl[[:space:]]*=[[:space:]]*1[[:space:]]*$/reapply_sysctl = 0/' "$tuned_main"
+        if grep -qE '^[[:space:]]*reapply_sysctl[[:space:]]*=' "$tuned_main"; then
+            # Match any value, not just "1": a line like "reapply_sysctl = 1 # note"
+            # or "= 2" matches the grep but not the old sed, silently leaving it on.
+            sed -i -E 's/^[[:space:]]*reapply_sysctl[[:space:]]*=.*$/reapply_sysctl = 0/' "$tuned_main"
             echo "Set reapply_sysctl = 0 in $tuned_main"
         else
             echo "reapply_sysctl = 0" >> "$tuned_main"
@@ -249,6 +254,17 @@ set_reapply_sysctl_off() {
     else
         echo "reapply_sysctl = 0" > "$tuned_main"
         echo "Created $tuned_main with reapply_sysctl = 0"
+    fi
+
+    # tuned reads tuned-main.conf only when the daemon starts (GlobalConfig.load_config
+    # runs from __init__), and `tuned-adm profile` does not re-read it. install_tuned.sh
+    # has already started tuned by this point, so without a restart the running daemon
+    # keeps reapply_sysctl = 1 and re-applies /etc/sysctl.d over the profile's [sysctl]
+    # values: tuned's _apply_sysctl_config_line logs "Overriding sysctl parameter" and
+    # writes the /etc/sysctl.d value anyway rather than skipping options the profile owns.
+    if [[ "$(cat "$tuned_main")" != "$before" ]] && systemctl is-active --quiet tuned; then
+        echo "tuned-main.conf changed; restarting tuned so reapply_sysctl takes effect"
+        systemctl restart tuned
     fi
 }
 


### PR DESCRIPTION
## Problem

Reported from an in-cluster run of `nvidia-tuned` 0.5.0 with `service: oci`, `accelerator: gb300`:

```
ERROR tuned.plugins.base: verify: failed: 'net.ipv6.conf.default.disable_ipv6' = '1', expected ''
ERROR tuned.plugins.base: verify: failed: 'net.ipv6.conf.all.disable_ipv6' = '1', expected ''
```

The profile's IPv6 sysctls were not in force, so RDMA VFs came up with no routable GID and `config-check` failed.

## Root cause

`prepare_nvidia_profiles.sh` writes `reapply_sysctl = 0` into `/etc/tuned/tuned-main.conf` during the **config** stage. But tuned reads that file only when the daemon starts: `GlobalConfig.load_config()` is called from `__init__`, and `tuned-adm profile` does not re-read it (`reload_profile_config` reloads *profiles*, not the global config). `install_tuned.sh` already started tuned back in the **apply** stage, so the running daemon still had `reapply_sysctl = 1`.

With that still set, `_instance_apply_static` calls `_apply_system_sysctl` after applying the profile. Critically, tuned does **not** skip options the profile owns:

```python
if option in instance_sysctl and instance_sysctl[option] != value:
    log.info("Overriding sysctl parameter '%s' from '%s' to '%s'" ...)
_write_sysctl(option, value, ignore_missing=True)   # writes the /etc/sysctl.d value anyway
```

The OCI node image disables IPv6 via `/etc/sysctl.d`, so that file's `disable_ipv6 = 1` clobbered the profile's `0` immediately after the profile applied.

## Fix

Restart tuned after changing `tuned-main.conf`, guarded so it only happens when the file actually changed (re-runs are no-ops, and the `prepare` step is not idempotence-tracked so it runs every time).

Also widen the rewrite to match any `reapply_sysctl` value. The old substitution anchored on a bare `1`, so `reapply_sysctl = 1 # note` or `= 2` matched the `grep` guard but not the `sed`, leaving the setting on while logging success.

## Testing

Docker suite not run locally. Verified the rewrite and restart-trigger logic across six inputs:

| Input | Result | Restart |
|---|---|---|
| `reapply_sysctl = 1` | `= 0` | yes |
| `reapply_sysctl = 1 # note` | `= 0` | yes (old sed missed this) |
| `reapply_sysctl = 2` | `= 0` | yes |
| `reapply_sysctl = 0` | unchanged | **no** (idempotent) |
| `# reapply_sysctl = 1` | appended | yes |
| `   reapply_sysctl=1` | `= 0` | yes |

`shellcheck` and `make license-check` clean.

## Open item

This explains the `= '1'` half of the failure. It does **not** explain `expected ''` in the same log line: `expected` comes straight from the parsed profile, and I traced every transform (ConfigParser -> `_expand_profile_dir` -> `Merger.options.update` -> `variables.expand` -> `_process_assignment_modifiers` -> `remove_ws`) and none can turn `"0"` into `""`. The shipped `tuned.conf.template` in the 0.5.0 image is byte-correct. If the sysctls still do not stick after this fix, `cat /etc/tuned/oci-gb300-performance/tuned.conf` on an affected node should settle it.
