### PR TITLE
feat(nvidia-tuned): add PCIe ACS fix and RDMA VF boot gate for OCI GB300

### DIFF
--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -79,7 +79,11 @@ profiles/
         ├── tuned.conf.template  # RDMA IPv6 defaults for OCI's IPv6/SLAAC RoCE fabric
         ├── script.sh            # Re-enables IPv6 on existing mlx5 RDMA VFs
         ├── nvidia-gb300-performance.conf   # Re-roots gb300 onto the bootloader-free base
-        └── nccl-topo-gb300.xml  # Installed to ${TOPO_PATH} by the write-nccl-topo config step
+        ├── nccl-topo-gb300.xml  # Installed to ${TOPO_PATH} by the write-nccl-topo config step
+        ├── pcie-acs-gb300.enabled          # Opts gb300 in to the configure-pcie-acs config step
+        └── rdma-vfs-ready-gb300/           # Installed by the install-rdma-vfs-ready config step
+            ├── rdma-vfs-ready.service
+            └── wait-rdma-vfs.sh
 ```
 
 Note: Profiles are stored in `profiles/` (not `root_dir/`) to avoid polluting the host filesystem during package extraction. The prepare scripts explicitly copy profiles to the appropriate tuned directories.
@@ -94,7 +98,18 @@ Note: Profiles are stored in `profiles/` (not `root_dir/`) to avoid polluting th
    - Copies the appropriate OS-specific workload profiles to the resolved tuned profiles dir (`/etc/tuned/profiles` on tuned >= 2.23, else `/etc/tuned`)
    - If a `service` is specified, creates service profile with dynamic `include=` pointing to the workload profile
 
-2. **Config stage**: The inherited `tuned` package applies the configured profile
+2. **Host setup steps**: three steps run between `prepare` and the profile apply. Each
+   resolves a bundled asset from the configured `service` and `accelerator` and is a
+   no-op when that pair ships nothing, so they cost nothing for pairs that do not use
+   them:
+   - `write-nccl-topo` installs `profiles/service/{service}/nccl-topo-{accelerator}.xml`
+     to `${TOPO_PATH}`
+   - `install-rdma-vfs-ready` installs and enables the systemd unit in
+     `profiles/service/{service}/rdma-vfs-ready-{accelerator}/`
+   - `configure-pcie-acs` runs the node's `rdma_topo` tool when
+     `profiles/service/{service}/pcie-acs-{accelerator}.enabled` is present
+
+3. **Config stage**: The inherited `tuned` package applies the configured profile
 
 ### Profile Name Construction
 
@@ -216,7 +231,7 @@ spec:
         service: aks
 ```
 
-**OCI tuning** (GB300 on OCI, applies without a reboot, installs an NCCL topology file):
+**OCI tuning** (GB300 on OCI: NCCL topology file, PCIe ACS correction, RDMA VF boot gate):
 
 ```yaml
 apiVersion: skyhook.nvidia.com/v1alpha1
@@ -230,7 +245,9 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: 0.5.0
+      version: 0.6.0
+      interrupt:
+        type: reboot
       env:
         - name: TOPO_PATH
           value: /etc/nccl/gb300-topo.xml
@@ -240,8 +257,28 @@ spec:
         service: oci
 ```
 
-No `interrupt` is needed: the `oci` gb300 chain carries no `[bootloader]` settings, so
-the profile applies live.
+`interrupt: {type: reboot}` is required as of 0.6.0, and stays required even with
+`CONFIGURE_PCIE_ACS=false`, because the RDMA VF gate is a boot-ordering unit. The tuned
+profile chain itself still carries no `[bootloader]` settings and applies live, but two
+host-level steps do need a reboot:
+
+- **PCIe ACS correction.** GB300 nodes ship with ACS enabled on the RoCE NIC root
+  ports, which blocks peer-to-peer DMA. The `configure-pcie-acs` step runs the node's
+  `rdma_topo` tool to generate a `pci=config_acs=...` bootloader drop-in, which only
+  takes effect on the next boot. Correcting it raised measured all_reduce peak busbw
+  from 360 GB/s to 426 GB/s on a 2 node, 8 GPU RoCE run and made DMA-BUF work, which
+  removes the need for `nvidia_peermem` and `NCCL_DMABUF_ENABLE=0` on nodes where the
+  correction takes effect. It only takes effect on kernels that honour
+  `pci=config_acs=`; on a node whose kernel does not, set `CONFIGURE_PCIE_ACS=false`
+  (see the environment variables below), keep `nvidia_peermem` loaded, and keep
+  `NCCL_DMABUF_ENABLE=0` set.
+- **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
+  `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
+  Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has
+  an effect from the next boot.
+
+Both steps are no-ops for every other `service`/`accelerator` pair, so existing `eks`,
+`aks`, and `bcm` deployments are unaffected and still need no `interrupt`.
 
 ### ConfigMap Fields
 
@@ -254,9 +291,11 @@ the profile applies live.
 > **gb300 / oci:** `gb300` ships a `performance` profile only. The base
 > `nvidia-gb300-performance` profile keeps the reboot-requiring `[bootloader]` tuning
 > (same as gb200); with `service=oci`, gb300 uses a bootloader-free profile chain
-> (`nvidia-gb300-noreboot-base`) so the tuning applies without a reboot. The `oci`
-> service also sets the RDMA IPv6 defaults that OCI's IPv6/SLAAC RoCE fabric needs, and
-> installs the bundled NCCL topology file (see `TOPO_PATH` below).
+> (`nvidia-gb300-noreboot-base`) so the tuning itself applies without a reboot. The
+> `oci` service also sets the RDMA IPv6 defaults that OCI's IPv6/SLAAC RoCE fabric
+> needs, and installs the bundled NCCL topology file (see `TOPO_PATH` below).
+> As of 0.6.0 the pair also runs the PCIe ACS correction and installs the RDMA VF boot
+> gate, both of which require `interrupt: {type: reboot}` on the custom resource.
 
 ## Available Profiles
 
@@ -284,13 +323,14 @@ the profile applies live.
 | `eks` | eks-specific settings (MAC address policy for CNI) |
 | `aks` | aks-specific settings (MAC address policy, grub.d bootloader workaround for Ubuntu) |
 | `bcm` | bcm-specific settings (bootloader-free vr200 chain, applies without a reboot) |
-| `oci` | oci-specific settings (RDMA IPv6 defaults, NCCL topology file, applies without a reboot) |
+| `oci` | oci-specific settings (RDMA IPv6 defaults, NCCL topology file, PCIe ACS correction and RDMA VF boot gate on gb300; requires `interrupt: {type: reboot}`) |
 
 ### Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `TOPO_PATH` | No | `/etc/nccl/topo.xml` | Absolute host path the bundled NCCL topology file is written to. Only used when the configured `service`/`accelerator` pair ships one (today `oci` + `gb300`); otherwise the step is a no-op. Point `NCCL_TOPO_FILE` at the same path in your workloads. |
+| `CONFIGURE_PCIE_ACS` | No | `true` | Set to `false` to skip the PCIe ACS correction and its checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Use this on nodes whose kernel does not honour `pci=config_acs=`, where the correction cannot take effect and the post-interrupt check would otherwise fail the node. |
 
 ## Adding OS-Specific Overrides
 
@@ -315,6 +355,24 @@ tuned-adm active
 tuned-adm verify
 ```
 
+On `service: oci` with `accelerator: gb300`, also verify the two host-level steps after
+the node has rebooted:
+
+```bash
+# PCIe ACS values are correct on the RoCE NIC root ports
+rdma_topo check
+
+# The kernel booted with the generated ACS argument
+grep -o 'pci=config_acs=[^ ]*' /proc/cmdline
+
+# The RDMA VF gate ran ahead of kubelet
+systemctl status rdma-vfs-ready.service
+journalctl -u rdma-vfs-ready.service
+
+# The VFs the gate waited for are present
+ls -d /sys/class/net/*/device/physfn | wc -l
+```
+
 ## Inheritance
 
 This package inherits all functionality from the base `tuned` package:
@@ -328,7 +386,7 @@ See the [tuned package README](../tuned/README.md) for complete documentation on
 
 ## Version
 
-- **Package Version**: 0.3.0
+- **Package Version**: 0.6.0
 - **Base Package**: tuned (latest via preprocess.sh)
 - **Schema Version**: v1
 

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -266,7 +266,7 @@ host-level steps do need a reboot:
   ports, which blocks peer-to-peer DMA. The `configure-pcie-acs` step runs the node's
   `rdma_topo` tool to generate a `pci=config_acs=...` bootloader drop-in, which only
   takes effect on the next boot. Correcting it raised measured all_reduce peak busbw
-  from 360 GB/s to 426 GB/s on a 2 node, 8 GPU RoCE run and made DMA-BUF work, which
+  from 360 GB/s to 426 GB/s on a two-node, eight-GPU RoCE run and made DMA-BUF work, which
   removes the need for `nvidia_peermem` and `NCCL_DMABUF_ENABLE=0` on nodes where the
   correction takes effect. It only takes effect on kernels that honour
   `pci=config_acs=`; on a node whose kernel does not, set `CONFIGURE_PCIE_ACS=false`

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -35,7 +35,7 @@ resolve bundled assets by service and accelerator and are no-ops when a pair shi
   RoCE NIC root ports, which blocks peer-to-peer DMA: `rdma_topo check` fails on every
   stock node and `mlx5dv_reg_dmabuf_mr` returns ENOTSUPP. The step runs the node's own
   `rdma_topo` tool to generate a `pci=config_acs=...` bootloader drop-in, then
-  regenerates the grub config. Measured on a 2 node, 8 GPU RoCE all_reduce run,
+  regenerates the grub config. Measured on a two-node, eight-GPU RoCE all_reduce run,
   correcting ACS raised peak busbw from 360 GB/s to 426 GB/s and made DMA-BUF work, so
   `nvidia_peermem` is no longer required and `NCCL_DMABUF_ENABLE=0` can be dropped on
   nodes where the correction takes effect.

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,53 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.6.0
+
+Adds two host-level fixes for GB300 nodes on OCI.
+
+**Upgrade note: `service: oci` with `accelerator: gb300` now requires
+`interrupt: {type: reboot}` on the custom resource.** Both new steps land settings that
+only take effect at boot, and the post-interrupt checks fail if the node has not
+rebooted. Add the interrupt block before rolling 0.6.0 out to those nodes. Nothing
+changes for `eks`, `aks`, `bcm`, or any other `service`/`accelerator` pair: both steps
+resolve bundled assets by service and accelerator and are no-ops when a pair ships none.
+
+- **New `config` step `configure-pcie-acs`.** GB300 nodes ship with ACS enabled on the
+  RoCE NIC root ports, which blocks peer-to-peer DMA: `rdma_topo check` fails on every
+  stock node and `mlx5dv_reg_dmabuf_mr` returns ENOTSUPP. The step runs the node's own
+  `rdma_topo` tool to generate a `pci=config_acs=...` bootloader drop-in, then
+  regenerates the grub config. Measured on a 2 node, 8 GPU RoCE all_reduce run,
+  correcting ACS raised peak busbw from 360 GB/s to 426 GB/s and made DMA-BUF work, so
+  `nvidia_peermem` is no longer required and `NCCL_DMABUF_ENABLE=0` can be dropped on
+  nodes where the correction takes effect.
+  The generated values hardcode local PCI addresses and are not portable across shapes,
+  so they are generated per node rather than baked into the image. The step opts in via
+  a bundled `profiles/service/oci/pcie-acs-gb300.enabled` marker.
+
+  The correction only takes effect on kernels that honour `pci=config_acs=`. On a node
+  whose kernel does not, the drop-in is written but ignored, and the post-interrupt
+  check fails the node with a message naming the cause, the cost, and the remedy. Set
+  `CONFIGURE_PCIE_ACS=false` in the package `env` on such nodes: that skips the
+  correction and its checks, and `nvidia_peermem` plus `NCCL_DMABUF_ENABLE=0` remain
+  required there. The reboot interrupt is still needed either way, for the VF gate.
+- **New `config` step `install-rdma-vfs-ready`.** The sriov device plugin enumerates PCI
+  devices once at startup and never rescans, but the Oracle Cloud Agent creates the RDMA
+  VFs roughly 70 seconds after boot. The plugin therefore started first, found nothing,
+  and the node advertised `nvidia.com/mlnxnics: 0` permanently until the pod was deleted
+  by hand. The step installs a `rdma-vfs-ready.service` unit that orders before
+  `kubelet.service` and waits for the VFs to appear. The wait always exits 0, including
+  on timeout and on a partial VF count that has stopped moving, so it can never strand a
+  node outside the cluster.
+- **New `post-interrupt-check` steps** assert the corrected ACS values are live and that
+  the VF gate ran during boot.
+- **New `uninstall` step** removes the `rdma-vfs-ready.service` unit and its helper, so
+  uninstalling the package does not leave an unowned unit ordering kubelet. The PCIe ACS
+  bootloader drop-in is deliberately left in place: it corrects a node-level hardware
+  misconfiguration rather than installing package state, and reverting it would degrade
+  RDMA performance and need another reboot. Remove
+  `/etc/default/grub.d/config-acs.cfg` by hand and re-run `update-grub` if you want the
+  stock ACS values back.
+
 ## 0.5.1
 
 Fixes profile `[sysctl]` values being silently overwritten by `/etc/sysctl.d`.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,10 +1,22 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.5.1",
+    "package_version": "0.6.0",
     "expected_config_files": ["accelerator"],
     "modes": {
         "uninstall": [
+            {
+                "name": "uninstall-rdma-vfs-ready",
+                "path": "uninstall_rdma_vfs_ready.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
             {
                 "name": "uninstall",
                 "path": "uninstall_tuned.sh",
@@ -19,6 +31,18 @@
             }
         ],
         "uninstall-check": [
+            {
+                "name": "uninstall-rdma-vfs-ready-check",
+                "path": "uninstall_rdma_vfs_ready_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
             {
                 "name": "uninstall-check",
                 "path": "uninstall_tuned_check.sh",
@@ -119,6 +143,30 @@
                 "upgrade_step": false
             },
             {
+                "name": "install-rdma-vfs-ready",
+                "path": "install_rdma_vfs_ready.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "configure-pcie-acs",
+                "path": "configure_pcie_acs.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": false,
+                "upgrade_step": false
+            },
+            {
                 "name": "config",
                 "path": "apply_tuned_profile.sh",
                 "arguments": [],
@@ -157,6 +205,30 @@
                 "upgrade_step": false
             },
             {
+                "name": "install-rdma-vfs-ready-check",
+                "path": "install_rdma_vfs_ready_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "configure-pcie-acs-check",
+                "path": "configure_pcie_acs_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
                 "name": "config-check",
                 "path": "apply_tuned_profile_check.sh",
                 "arguments": [],
@@ -170,6 +242,30 @@
             }
         ],
         "post-interrupt-check": [
+            {
+                "name": "post-interrupt-rdma-vfs-ready-check",
+                "path": "post_interrupt_rdma_vfs_ready_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "post-interrupt-pcie-acs-check",
+                "path": "post_interrupt_pcie_acs_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
             {
                 "name": "post-interrupt-check",
                 "path": "post_interrupt_tuned_check.sh",

--- a/nvidia-tuned/profiles/service/oci/pcie-acs-gb300.enabled
+++ b/nvidia-tuned/profiles/service/oci/pcie-acs-gb300.enabled
@@ -1,0 +1,6 @@
+# Marker: opt this service/accelerator pair in to the PCIe ACS correction run by
+# skyhook_dir/configure_pcie_acs.sh. The file is a switch; its contents are ignored.
+#
+# GB300 nodes on OCI ship with ACS enabled on the RoCE NIC root ports, which blocks
+# peer-to-peer DMA. Correcting it requires a reboot, so a custom resource selecting
+# service=oci with accelerator=gb300 must declare interrupt: {type: reboot}.

--- a/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/rdma-vfs-ready.service
+++ b/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/rdma-vfs-ready.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Wait for OCA to create RDMA VFs before kubelet starts
+Documentation=https://github.com/NVIDIA/nodewright-packages/tree/main/nvidia-tuned
+After=snap.oracle-cloud-agent.oracle-cloud-agent.service
+Wants=snap.oracle-cloud-agent.oracle-cloud-agent.service
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+TimeoutStartSec=300
+ExecStart=/usr/local/sbin/wait-rdma-vfs.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
+++ b/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
@@ -28,7 +28,9 @@
 # the last two VFs appearing within 2 seconds of each other. A 60 second ceiling would
 # be too short.
 
-set -uo pipefail
+# Strict mode, with the always-exit-0 contract preserved by the wrapper at the bottom:
+# main() aborts on an unexpected error and the node is released rather than held.
+set -euo pipefail
 
 # Number of VFs a healthy BM.GPU.GB300.4 presents.
 EXPECTED_VFS="${EXPECTED_VFS:-4}"
@@ -41,6 +43,22 @@ POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-2}"
 STABLE_POLLS="${STABLE_POLLS:-5}"
 # Where network interfaces are enumerated. Overridable so tests can stage a fake tree.
 SYS_CLASS_NET="${SYS_CLASS_NET:-/sys/class/net}"
+
+# Fall back to the default when an override is not a positive integer. A zero or
+# non-numeric POLL_INTERVAL_SECS in particular would stop `elapsed` from advancing and
+# turn the wait into a busy loop that spins until systemd's TimeoutStartSec fires.
+require_positive_int() {
+    local name="$1" default="$2" value="${!1}"
+    if [[ ! "${value}" =~ ^[0-9]+$ ]] || [[ "${value}" -lt 1 ]]; then
+        echo "WARNING: ${name}='${value}' is not a positive integer; using ${default}"
+        printf -v "${name}" '%s' "${default}"
+    fi
+}
+
+require_positive_int EXPECTED_VFS 4
+require_positive_int TIMEOUT_SECS 300
+require_positive_int POLL_INTERVAL_SECS 2
+require_positive_int STABLE_POLLS 5
 
 count_vfs() {
     local netdev total=0
@@ -82,4 +100,9 @@ main() {
     return 0
 }
 
-main "$@"
+# Always exit 0. This unit is ordered Before=kubelet.service, so failing here would
+# delay the node joining the cluster over a wait that is best effort by design.
+if ! main "$@"; then
+    echo "WARNING: RDMA VF wait aborted unexpectedly; releasing kubelet anyway"
+fi
+exit 0

--- a/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
+++ b/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Waits for the Oracle Cloud Agent to create the RDMA virtual functions, then returns so
+# kubelet can start. Run by rdma-vfs-ready.service.
+#
+# This script ALWAYS exits 0. It is ordered Before=kubelet.service, so a non-zero exit
+# would strand the node outside the cluster. Waiting is best effort: if the VFs never
+# appear, the node still joins and the missing capacity shows up as
+# nvidia.com/mlnxnics: 0 rather than as a node that never registers.
+#
+# Measured on BM.GPU.GB300.4: the count went 0 -> 3 -> 4 over roughly 72 seconds, with
+# the last two VFs appearing within 2 seconds of each other. A 60 second ceiling would
+# be too short.
+
+set -uo pipefail
+
+# Number of VFs a healthy BM.GPU.GB300.4 presents.
+EXPECTED_VFS="${EXPECTED_VFS:-4}"
+# Overall ceiling, in seconds, before giving up and letting kubelet start.
+TIMEOUT_SECS="${TIMEOUT_SECS:-300}"
+# Seconds between polls.
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-2}"
+# Consecutive polls with a non-zero, unchanged count that count as settled. This is the
+# degraded-NIC escape hatch: fewer VFs than expected, but the number has stopped moving.
+STABLE_POLLS="${STABLE_POLLS:-5}"
+# Where network interfaces are enumerated. Overridable so tests can stage a fake tree.
+SYS_CLASS_NET="${SYS_CLASS_NET:-/sys/class/net}"
+
+count_vfs() {
+    local netdev total=0
+    # A VF netdev has a physfn symlink back to its physical function.
+    for netdev in "${SYS_CLASS_NET}"/*; do
+        [[ -e "${netdev}/device/physfn" ]] || continue
+        total=$((total + 1))
+    done
+    echo "${total}"
+}
+
+main() {
+    local elapsed=0 count last_count=-1 stable=0
+
+    while [[ "${elapsed}" -lt "${TIMEOUT_SECS}" ]]; do
+        count="$(count_vfs)"
+
+        if [[ "${count}" -ge "${EXPECTED_VFS}" ]]; then
+            echo "Found ${count} RDMA VFs after ${elapsed}s; releasing kubelet"
+            return 0
+        fi
+
+        if [[ "${count}" -gt 0 && "${count}" -eq "${last_count}" ]]; then
+            stable=$((stable + 1))
+            if [[ "${stable}" -ge "${STABLE_POLLS}" ]]; then
+                echo "VF count settled at ${count} (expected ${EXPECTED_VFS}) after ${elapsed}s; releasing kubelet"
+                return 0
+            fi
+        else
+            stable=0
+        fi
+
+        last_count="${count}"
+        sleep "${POLL_INTERVAL_SECS}"
+        elapsed=$((elapsed + POLL_INTERVAL_SECS))
+    done
+
+    echo "Timed out after ${TIMEOUT_SECS}s with $(count_vfs) RDMA VFs (expected ${EXPECTED_VFS}); releasing kubelet anyway"
+    return 0
+}
+
+main "$@"

--- a/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
+++ b/nvidia-tuned/profiles/service/oci/rdma-vfs-ready-gb300/wait-rdma-vfs.sh
@@ -102,7 +102,18 @@ main() {
 
 # Always exit 0. This unit is ordered Before=kubelet.service, so failing here would
 # delay the node joining the cluster over a wait that is best effort by design.
-if ! main "$@"; then
-    echo "WARNING: RDMA VF wait aborted unexpectedly; releasing kubelet anyway"
-fi
-exit 0
+#
+# The conversion happens in an EXIT trap rather than by calling main in an `if` or `||`
+# condition. Bash suppresses errexit throughout a function invoked as a condition, so
+# `if ! main` would let main run past a failed command, keep advancing `elapsed`, and
+# return success without ever reporting the abort.
+release_kubelet_on_exit() {
+    local status=$?
+    if [[ "${status}" -ne 0 ]]; then
+        echo "WARNING: RDMA VF wait aborted unexpectedly (status ${status}); releasing kubelet anyway"
+    fi
+    exit 0
+}
+trap release_kubelet_on_exit EXIT
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Corrects the PCIe ACS settings on the RoCE NIC root ports so peer-to-peer DMA works.
+#
+# Why this exists: GB300 nodes ship with ACS enabled on the NIC root ports, which blocks
+# peer-to-peer DMA between the GPUs and the RoCE NICs. `rdma_topo check` fails on every
+# stock node, mlx5dv_reg_dmabuf_mr returns ENOTSUPP, and NCCL falls back to a slower
+# path. Correcting ACS raised measured all_reduce peak busbw from 360 GB/s to 426 GB/s
+# on a 2 node, 8 GPU RoCE run, and made DMA-BUF work, which removes the need for
+# nvidia_peermem and NCCL_DMABUF_ENABLE=0 wherever the correction takes effect.
+#
+# The values are per-topology: `rdma_topo write-grub-acs` generates a
+# `pci=config_acs=...` line containing the local PCI addresses into
+# /etc/default/grub.d/config-acs.cfg. That output is NOT portable across shapes, so it
+# is generated on the node rather than baked into this image. The tool itself is
+# shape-agnostic and idempotent.
+#
+# This step self-gates on a bundled marker file at:
+#   ${SKYHOOK_DIR}/profiles/service/${service}/pcie-acs-${accelerator}.enabled
+# so every service/accelerator combination without the marker is a no-op. Today only
+# service=oci, accelerator=gb300 opts in.
+#
+# On top of that, operators can turn the step off per deployment with the
+# CONFIGURE_PCIE_ACS env var. It defaults to on. The escape hatch matters because
+# `pci=config_acs=` is not honoured by every kernel: on a kernel that ignores it the
+# generated drop-in has no effect and nvidia_peermem stays required. Rather than probe
+# kernel versions, the step is simply switchable.
+#
+# The change lands on the kernel command line, so it requires a reboot. Declare
+# `interrupt: {type: reboot}` on the custom resource; post_interrupt_pcie_acs_check.sh
+# reports on the corrected ACS values after the reboot.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+# Overridable so tests can point at a stub.
+RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
+
+# Returns 0 unless the operator switched the step off via CONFIGURE_PCIE_ACS.
+acs_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_PCIE_ACS:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Returns 0 when the configured service/accelerator opts in to the ACS fix.
+acs_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/pcie-acs-${accelerator}.enabled" ]]
+}
+
+# Regenerate the bootloader config. Mirrors the fallback chain in kdump's
+# update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        exit 1
+    fi
+}
+
+main() {
+    if ! acs_enabled; then
+        echo "PCIe ACS correction not enabled for this service/accelerator; nothing to do"
+        return 0
+    fi
+
+    if ! acs_requested; then
+        echo "PCIe ACS correction switched off via CONFIGURE_PCIE_ACS; nothing to do"
+        return 0
+    fi
+
+    if ! command -v "${RDMA_TOPO_BIN}" >/dev/null 2>&1; then
+        echo "ERROR: ${RDMA_TOPO_BIN} not found. It ships in the node image for this shape;"
+        echo "       a node without it cannot have its ACS settings corrected."
+        exit 1
+    fi
+
+    # `rdma_topo check` reads the live kernel state, so it keeps failing between the
+    # grub write and the reboot. Re-running write-grub-acs in that window is harmless:
+    # the tool regenerates the same drop-in from the same topology.
+    if "${RDMA_TOPO_BIN}" check; then
+        echo "PCIe ACS values are already correct; nothing to do"
+        return 0
+    fi
+
+    echo "PCIe ACS check failed; generating bootloader ACS configuration"
+    "${RDMA_TOPO_BIN}" write-grub-acs
+    regenerate_grub
+    echo "Wrote PCIe ACS bootloader configuration; a reboot is required for it to take effect"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
@@ -22,7 +22,7 @@
 # peer-to-peer DMA between the GPUs and the RoCE NICs. `rdma_topo check` fails on every
 # stock node, mlx5dv_reg_dmabuf_mr returns ENOTSUPP, and NCCL falls back to a slower
 # path. Correcting ACS raised measured all_reduce peak busbw from 360 GB/s to 426 GB/s
-# on a 2 node, 8 GPU RoCE run, and made DMA-BUF work, which removes the need for
+# on a two-node, eight-GPU RoCE run, and made DMA-BUF work, which removes the need for
 # nvidia_peermem and NCCL_DMABUF_ENABLE=0 wherever the correction takes effect.
 #
 # The values are per-topology: `rdma_topo write-grub-acs` generates a
@@ -44,7 +44,7 @@
 #
 # The change lands on the kernel command line, so it requires a reboot. Declare
 # `interrupt: {type: reboot}` on the custom resource; post_interrupt_pcie_acs_check.sh
-# reports on the corrected ACS values after the reboot.
+# then verifies the corrected values are live, and fails if they are not.
 
 set -euo pipefail
 

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies configure_pcie_acs.sh left the node in a state that will have correct ACS
+# values after the next boot.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly. When the service/accelerator pair does not opt in,
+# there is nothing to verify and this exits 0.
+#
+# This runs during config-check, before the reboot, so `rdma_topo check` is still
+# expected to fail: it reads live kernel state and the fix lands on the kernel command
+# line. Passing means either the node was already correct, or the bootloader drop-in is
+# in place. post_interrupt_pcie_acs_check.sh asserts the values are actually live.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+ACS_GRUB_DROPIN="${ACS_GRUB_DROPIN:-/etc/default/grub.d/config-acs.cfg}"
+RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
+
+# Mirrors acs_requested() in configure_pcie_acs.sh.
+acs_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_PCIE_ACS:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Mirrors acs_enabled() in configure_pcie_acs.sh.
+acs_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/pcie-acs-${accelerator}.enabled" ]]
+}
+
+main() {
+    if ! acs_enabled; then
+        echo "PCIe ACS correction not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if ! acs_requested; then
+        echo "PCIe ACS correction switched off via CONFIGURE_PCIE_ACS; nothing to verify"
+        return 0
+    fi
+
+    if ! command -v "${RDMA_TOPO_BIN}" >/dev/null 2>&1; then
+        echo "ERROR: ${RDMA_TOPO_BIN} not found"
+        exit 1
+    fi
+
+    if "${RDMA_TOPO_BIN}" check; then
+        echo "Verified PCIe ACS values are correct"
+        return 0
+    fi
+
+    if [[ ! -f "${ACS_GRUB_DROPIN}" ]]; then
+        echo "ERROR: PCIe ACS check failed and no bootloader drop-in at ${ACS_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    if ! grep -q "config_acs" "${ACS_GRUB_DROPIN}"; then
+        echo "ERROR: ${ACS_GRUB_DROPIN} does not contain a config_acs setting"
+        exit 1
+    fi
+
+    echo "Verified PCIe ACS bootloader drop-in at ${ACS_GRUB_DROPIN}; pending reboot"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -87,21 +87,20 @@ main() {
         exit 1
     fi
 
-    # Match an active assignment, not a commented example, so a drop-in that would
-    # contribute nothing to the kernel command line fails here rather than surfacing as
-    # a post-interrupt failure after the reboot.
+    # Match an active assignment, so a drop-in that would contribute nothing to the
+    # kernel command line fails here rather than surfacing as a post-interrupt failure
+    # after the reboot.
     #
-    # The optional group is what makes this correct, and it is easy to "simplify" wrong:
-    #   ^[[:space:]]*[^#].*pci=config_acs=          matches "  # pci=config_acs=",
-    #                                               because [^#] consumes a second space
-    #   ^[[:space:]]*[^#[:space:]].*pci=config_acs= rejects a tab-indented active line,
-    #                                               because .* then needs a second token
-    # Making the leading group optional covers both: the token may start at the first
-    # non-blank character, but that character must not be '#'.
-    #
-    # A `grep -v | grep -q` pipeline would also be correct but can return 141 under
-    # pipefail when grep -q exits early and the upstream grep takes SIGPIPE.
-    if ! grep -Eq '^[[:space:]]*([^#[:space:]].*)?pci=config_acs=' "${ACS_GRUB_DROPIN}"; then
+    # Strip each line's comment first, then look for the token. Doing it in one awk pass
+    # rather than a regex is deliberate: every single-pattern form of this test has a
+    # blind spot. '[^#].*' matches an indented comment (it consumes a second space),
+    # '[^#[:space:]].*' rejects a tab-indented active line (the '.*' then needs a second
+    # token), and anchoring only the line prefix still accepts a trailing inline comment
+    # such as 'GRUB_CMDLINE_LINUX_DEFAULT="..." # pci=config_acs=x'. Removing the comment
+    # up front makes all of those fall out. awk is also a single process, so there is no
+    # pipeline that could return 141 under pipefail on an early exit.
+    if ! awk '{ sub(/#.*/, ""); if ($0 ~ /pci=config_acs=/) found = 1 } END { exit !found }' \
+        "${ACS_GRUB_DROPIN}"; then
         echo "ERROR: ${ACS_GRUB_DROPIN} does not contain an active pci=config_acs setting"
         exit 1
     fi

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -87,8 +87,11 @@ main() {
         exit 1
     fi
 
-    if ! grep -q "config_acs" "${ACS_GRUB_DROPIN}"; then
-        echo "ERROR: ${ACS_GRUB_DROPIN} does not contain a config_acs setting"
+    # Match an active assignment, not a commented example or an incidental mention, so
+    # a drop-in that would contribute nothing to the kernel command line still fails
+    # here rather than surfacing as a post-interrupt failure after the reboot.
+    if ! grep -Eq '^[[:space:]]*[^#].*pci=config_acs=' "${ACS_GRUB_DROPIN}"; then
+        echo "ERROR: ${ACS_GRUB_DROPIN} does not contain an active pci=config_acs setting"
         exit 1
     fi
 

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -91,11 +91,17 @@ main() {
     # contribute nothing to the kernel command line fails here rather than surfacing as
     # a post-interrupt failure after the reboot.
     #
-    # Comments are stripped first rather than folded into one pattern: an expression
-    # like '^[[:space:]]*[^#].*pci=config_acs=' still matches "  # pci=config_acs=..."
-    # because [^#] can consume a second space, and tightening it to [^#[:space:]]
-    # then wrongly rejects a tab-indented active line.
-    if ! grep -v '^[[:space:]]*#' "${ACS_GRUB_DROPIN}" | grep -q 'pci=config_acs='; then
+    # The optional group is what makes this correct, and it is easy to "simplify" wrong:
+    #   ^[[:space:]]*[^#].*pci=config_acs=          matches "  # pci=config_acs=",
+    #                                               because [^#] consumes a second space
+    #   ^[[:space:]]*[^#[:space:]].*pci=config_acs= rejects a tab-indented active line,
+    #                                               because .* then needs a second token
+    # Making the leading group optional covers both: the token may start at the first
+    # non-blank character, but that character must not be '#'.
+    #
+    # A `grep -v | grep -q` pipeline would also be correct but can return 141 under
+    # pipefail when grep -q exits early and the upstream grep takes SIGPIPE.
+    if ! grep -Eq '^[[:space:]]*([^#[:space:]].*)?pci=config_acs=' "${ACS_GRUB_DROPIN}"; then
         echo "ERROR: ${ACS_GRUB_DROPIN} does not contain an active pci=config_acs setting"
         exit 1
     fi

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -87,10 +87,15 @@ main() {
         exit 1
     fi
 
-    # Match an active assignment, not a commented example or an incidental mention, so
-    # a drop-in that would contribute nothing to the kernel command line still fails
-    # here rather than surfacing as a post-interrupt failure after the reboot.
-    if ! grep -Eq '^[[:space:]]*[^#].*pci=config_acs=' "${ACS_GRUB_DROPIN}"; then
+    # Match an active assignment, not a commented example, so a drop-in that would
+    # contribute nothing to the kernel command line fails here rather than surfacing as
+    # a post-interrupt failure after the reboot.
+    #
+    # Comments are stripped first rather than folded into one pattern: an expression
+    # like '^[[:space:]]*[^#].*pci=config_acs=' still matches "  # pci=config_acs=..."
+    # because [^#] can consume a second space, and tightening it to [^#[:space:]]
+    # then wrongly rejects a tab-indented active line.
+    if ! grep -v '^[[:space:]]*#' "${ACS_GRUB_DROPIN}" | grep -q 'pci=config_acs='; then
         echo "ERROR: ${ACS_GRUB_DROPIN} does not contain an active pci=config_acs setting"
         exit 1
     fi

--- a/nvidia-tuned/skyhook_dir/install_rdma_vfs_ready.sh
+++ b/nvidia-tuned/skyhook_dir/install_rdma_vfs_ready.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Installs a boot-time systemd gate that holds kubelet until the cloud provider has
+# created the RDMA virtual functions.
+#
+# Why this exists: the sriov device plugin enumerates PCI devices once at startup and
+# never rescans. On OCI GB300 the Oracle Cloud Agent creates the RDMA VFs roughly 70
+# seconds after boot, so the plugin starts first, finds nothing, and the node advertises
+# nvidia.com/mlnxnics: 0 permanently until the pod is deleted by hand. Ordering kubelet
+# after VF creation removes the race.
+#
+# The unit and its helper are looked up at:
+#   ${SKYHOOK_DIR}/profiles/service/${service}/rdma-vfs-ready-${accelerator}/
+# so this step self-gates: every service/accelerator combination that does not ship the
+# directory is a no-op. Today only service=oci, accelerator=gb300 ships one.
+#
+# The unit is enabled but not started. It is a boot-ordering gate, so it only has an
+# effect from the next boot; activation happens through the package's reboot interrupt
+# and is asserted by the post-interrupt check.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+UNIT_NAME="rdma-vfs-ready.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+HELPER_NAME="wait-rdma-vfs.sh"
+HELPER_DEST="/usr/local/sbin/${HELPER_NAME}"
+
+# Resolve the bundled asset directory for the configured service/accelerator, if any.
+# Echoes the source directory on success; echoes nothing when there is nothing to install.
+resolve_asset_dir() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 0
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 0
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 0
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 0
+
+    local candidate="${PROFILES_DIR}/service/${service}/rdma-vfs-ready-${accelerator}"
+    [[ -d "${candidate}" ]] || return 0
+    [[ -f "${candidate}/${UNIT_NAME}" ]] || return 0
+    [[ -f "${candidate}/${HELPER_NAME}" ]] || return 0
+
+    echo "${candidate}"
+}
+
+main() {
+    local src
+    src="$(resolve_asset_dir)"
+
+    if [[ -z "${src}" ]]; then
+        echo "No bundled RDMA VF readiness unit for this service/accelerator; nothing to do"
+        return 0
+    fi
+
+    install -D -m 0755 "${src}/${HELPER_NAME}" "${HELPER_DEST}"
+    echo "Installed ${src}/${HELPER_NAME} -> ${HELPER_DEST}"
+
+    install -D -m 0644 "${src}/${UNIT_NAME}" "${UNIT_DEST}"
+    echo "Installed ${src}/${UNIT_NAME} -> ${UNIT_DEST}"
+
+    systemctl daemon-reload
+
+    # Enable only. Starting it now would be a no-op on a node whose VFs already exist,
+    # and the point of the unit is the boot ordering it establishes for the next boot.
+    systemctl enable "${UNIT_NAME}"
+    echo "Enabled ${UNIT_NAME}; it takes effect on the next boot"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/install_rdma_vfs_ready_check.sh
+++ b/nvidia-tuned/skyhook_dir/install_rdma_vfs_ready_check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies install_rdma_vfs_ready.sh laid down and enabled the RDMA VF readiness unit.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly. When the service/accelerator pair ships no unit,
+# there is nothing to verify and this exits 0.
+#
+# This runs during config-check, before the reboot, so it asserts the unit is installed
+# and enabled but not that it has run. post_interrupt_rdma_vfs_ready_check.sh covers
+# the post-reboot state.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+UNIT_NAME="rdma-vfs-ready.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+HELPER_NAME="wait-rdma-vfs.sh"
+HELPER_DEST="/usr/local/sbin/${HELPER_NAME}"
+
+# Mirrors resolve_asset_dir() in install_rdma_vfs_ready.sh.
+resolve_asset_dir() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 0
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 0
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 0
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 0
+
+    local candidate="${PROFILES_DIR}/service/${service}/rdma-vfs-ready-${accelerator}"
+    [[ -d "${candidate}" ]] || return 0
+    [[ -f "${candidate}/${UNIT_NAME}" ]] || return 0
+    [[ -f "${candidate}/${HELPER_NAME}" ]] || return 0
+
+    echo "${candidate}"
+}
+
+main() {
+    local src
+    src="$(resolve_asset_dir)"
+
+    if [[ -z "${src}" ]]; then
+        echo "No bundled RDMA VF readiness unit for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if [[ ! -f "${HELPER_DEST}" ]]; then
+        echo "ERROR: helper script missing at: ${HELPER_DEST}"
+        exit 1
+    fi
+
+    if ! cmp -s "${src}/${HELPER_NAME}" "${HELPER_DEST}"; then
+        echo "ERROR: ${HELPER_DEST} does not match bundled ${src}/${HELPER_NAME}"
+        exit 1
+    fi
+
+    if [[ ! -x "${HELPER_DEST}" ]]; then
+        echo "ERROR: ${HELPER_DEST} is not executable"
+        exit 1
+    fi
+
+    if [[ ! -f "${UNIT_DEST}" ]]; then
+        echo "ERROR: unit file missing at: ${UNIT_DEST}"
+        exit 1
+    fi
+
+    if ! cmp -s "${src}/${UNIT_NAME}" "${UNIT_DEST}"; then
+        echo "ERROR: ${UNIT_DEST} does not match bundled ${src}/${UNIT_NAME}"
+        exit 1
+    fi
+
+    if ! systemctl is-enabled --quiet "${UNIT_NAME}"; then
+        echo "ERROR: ${UNIT_NAME} is not enabled"
+        exit 1
+    fi
+
+    echo "Verified ${UNIT_NAME} is installed and enabled"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
@@ -16,17 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Reports whether the corrected PCIe ACS values are live after the reboot interrupt.
+# Verifies the corrected PCIe ACS values are live after the reboot interrupt.
 #
-# This check REPORTS, it does not gate. It exits 0 even when ACS is still wrong, and
-# says so loudly instead. Whether the kernel honours `pci=config_acs=` is a property of
-# the node image rather than something this package controls, so failing here would
-# quarantine nodes over an environment mismatch with no path to convergence. The node
-# stays in service without the ACS speedup, and the warning below tells whoever
-# investigates exactly what happened and what to do.
+# This check GATES: if the correction was requested and did not take effect, it exits
+# non-zero and blocks post-interrupt validation, rather than letting the node quietly
+# run degraded. The escape hatch is explicit rather than implicit: an operator who knows
+# a node cannot support the correction sets CONFIGURE_PCIE_ACS=false, which skips both
+# the correction and this check.
 #
-# The paired config-check is stricter on purpose: it fails when the drop-in was not
-# written, because that is this package not doing its job.
+# Because a failure here stops the package, the message must be self-contained. It names
+# the cause, what the node loses, and the switch to set. See fail_acs_not_applied().
 
 set -uo pipefail
 

--- a/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reports whether the corrected PCIe ACS values are live after the reboot interrupt.
+#
+# This check REPORTS, it does not gate. It exits 0 even when ACS is still wrong, and
+# says so loudly instead. Whether the kernel honours `pci=config_acs=` is a property of
+# the node image rather than something this package controls, so failing here would
+# quarantine nodes over an environment mismatch with no path to convergence. The node
+# stays in service without the ACS speedup, and the warning below tells whoever
+# investigates exactly what happened and what to do.
+#
+# The paired config-check is stricter on purpose: it fails when the drop-in was not
+# written, because that is this package not doing its job.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
+PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
+
+# Mirrors acs_requested() in configure_pcie_acs.sh.
+acs_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_PCIE_ACS:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Mirrors acs_enabled() in configure_pcie_acs.sh.
+acs_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/pcie-acs-${accelerator}.enabled" ]]
+}
+
+main() {
+    if ! acs_enabled; then
+        echo "PCIe ACS correction not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if ! acs_requested; then
+        echo "PCIe ACS correction switched off via CONFIGURE_PCIE_ACS; nothing to verify"
+        return 0
+    fi
+
+    if ! command -v "${RDMA_TOPO_BIN}" >/dev/null 2>&1; then
+        fail_acs_not_applied "${RDMA_TOPO_BIN} is not installed on this node, so the ACS values cannot be read."
+    fi
+
+    if ! "${RDMA_TOPO_BIN}" check; then
+        if grep -q "config_acs" "${PROC_CMDLINE}"; then
+            fail_acs_not_applied \
+                "The booted kernel command line carries the config_acs argument but the ACS values are still wrong, so the kernel did not act on it. This is what a kernel without pci=config_acs= support looks like."
+        else
+            fail_acs_not_applied \
+                "The booted kernel command line (${PROC_CMDLINE}) carries no config_acs argument, so the generated drop-in never reached the kernel. Check for a later-sorting file in /etc/default/grub.d/ that overwrites GRUB_CMDLINE_LINUX_DEFAULT, and check which entry GRUB_DEFAULT boots."
+        fi
+    fi
+
+    echo "Verified PCIe ACS values are correct after reboot"
+}
+
+# Say clearly what is wrong, what it costs, and what to do, then fail. This is the only
+# place an operator investigating the failure will look, so it must be self-contained.
+fail_acs_not_applied() {
+    cat <<EOF
+ERROR: PCIe ACS correction was requested but did not take effect on this node.
+
+  ${1}
+
+  Impact: peer-to-peer DMA between the GPUs and the RoCE NICs stays blocked, so RDMA
+  throughput is roughly 15% lower and DMA-BUF does not work. Workloads on this node
+  still need nvidia_peermem loaded and NCCL_DMABUF_ENABLE=0 set.
+
+  If this node cannot support the correction (for example its kernel does not honour
+  pci=config_acs=), set CONFIGURE_PCIE_ACS=false in the package env on the custom
+  resource. That skips the correction and this check, and the node proceeds without
+  the ACS speedup.
+EOF
+    exit 1
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_rdma_vfs_ready_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_rdma_vfs_ready_check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies the RDMA VF readiness gate actually ran during the boot that followed the
+# package's reboot interrupt.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly. When the service/accelerator pair ships no unit,
+# there is nothing to verify and this exits 0.
+#
+# The unit is Type=oneshot with RemainAfterExit=true and always exits 0, so an active
+# unit means the boot-ordering gate ran ahead of kubelet. This deliberately does not
+# assert a VF count: the unit tolerates a degraded NIC by design, and failing the check
+# here would quarantine a node that is otherwise fine.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+UNIT_NAME="rdma-vfs-ready.service"
+
+# Mirrors resolve_asset_dir() in install_rdma_vfs_ready.sh.
+resolve_asset_dir() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 0
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 0
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 0
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 0
+
+    local candidate="${PROFILES_DIR}/service/${service}/rdma-vfs-ready-${accelerator}"
+    [[ -d "${candidate}" ]] || return 0
+    [[ -f "${candidate}/${UNIT_NAME}" ]] || return 0
+
+    echo "${candidate}"
+}
+
+main() {
+    local src
+    src="$(resolve_asset_dir)"
+
+    if [[ -z "${src}" ]]; then
+        echo "No bundled RDMA VF readiness unit for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if ! systemctl is-enabled --quiet "${UNIT_NAME}"; then
+        echo "ERROR: ${UNIT_NAME} is not enabled"
+        exit 1
+    fi
+
+    if ! systemctl is-active --quiet "${UNIT_NAME}"; then
+        echo "ERROR: ${UNIT_NAME} did not run during boot"
+        systemctl status --no-pager "${UNIT_NAME}" || true
+        exit 1
+    fi
+
+    echo "Verified ${UNIT_NAME} ran during boot"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
@@ -221,6 +221,7 @@ deploy_service_profile() {
         filename=$(basename "$file")
         [ "$filename" = "tuned.conf.template" ] && continue
         [[ "$filename" == *.conf ]] && continue  # Skip .conf files (they're service-specific profiles)
+        [[ "$filename" == *.enabled ]] && continue  # Skip opt-in markers read by agent steps, not tuned
         cp "$file" "$TUNED_PROFILES_DIR/$final_profile_name/$filename"
         chmod +x "$TUNED_PROFILES_DIR/$final_profile_name/$filename" 2>/dev/null || true
         echo "Copied service file: $filename"

--- a/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready.sh
@@ -42,9 +42,11 @@ HELPER_DEST="/usr/local/sbin/wait-rdma-vfs.sh"
 
 main() {
     if [[ ! -f "${UNIT_DEST}" ]]; then
-        echo "${UNIT_NAME} is not installed; nothing to do"
-        rm -f "${HELPER_DEST}"
-        return 0
+        # Informational only. A missing unit file does not mean a clean host: a partial
+        # install, or a hand-removed unit file, can leave the enablement symlink behind,
+        # and skipping the disable here would leave the uninstall check failing. So fall
+        # through and run the full teardown regardless.
+        echo "${UNIT_NAME} unit file is not present; running teardown anyway"
     fi
 
     # The unit may be enabled, disabled, or already half removed; none of that should

--- a/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Removes the RDMA VF readiness gate installed by install_rdma_vfs_ready.sh.
+#
+# This runs unconditionally rather than self-gating on the service/accelerator assets:
+# uninstall must also clean up after a custom resource whose configmaps have since
+# changed, so it keys on what is on the host, not on what the package currently bundles.
+# Removing a unit that was never installed is a no-op.
+#
+# Leaving the unit behind would keep ordering kubelet after a gate that no package owns
+# any more. The gate always exits 0, so the worst case is a delayed boot rather than a
+# node that never joins, but it is still ours to remove.
+#
+# The PCIe ACS bootloader drop-in written by configure_pcie_acs.sh is deliberately NOT
+# removed here. It corrects a hardware misconfiguration on the node rather than
+# installing package state, reverting it would degrade RDMA performance, and it would
+# not take effect until another reboot. Remove
+# /etc/default/grub.d/config-acs.cfg by hand and re-run update-grub if you genuinely
+# want the stock ACS values back.
+
+set -euo pipefail
+
+UNIT_NAME="rdma-vfs-ready.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+HELPER_DEST="/usr/local/sbin/wait-rdma-vfs.sh"
+
+main() {
+    if [[ ! -f "${UNIT_DEST}" ]]; then
+        echo "${UNIT_NAME} is not installed; nothing to do"
+        rm -f "${HELPER_DEST}"
+        return 0
+    fi
+
+    # The unit may be enabled, disabled, or already half removed; none of that should
+    # stop the uninstall.
+    systemctl disable --now "${UNIT_NAME}" || true
+
+    rm -f "${UNIT_DEST}"
+    rm -f "${HELPER_DEST}"
+
+    systemctl daemon-reload
+    echo "Removed ${UNIT_NAME} and ${HELPER_DEST}"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready_check.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_rdma_vfs_ready_check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies uninstall_rdma_vfs_ready.sh removed the RDMA VF readiness gate.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly.
+
+set -uo pipefail
+
+UNIT_NAME="rdma-vfs-ready.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+HELPER_DEST="/usr/local/sbin/wait-rdma-vfs.sh"
+
+main() {
+    if [[ -e "${UNIT_DEST}" ]]; then
+        echo "ERROR: ${UNIT_DEST} still present"
+        exit 1
+    fi
+
+    if [[ -e "${HELPER_DEST}" ]]; then
+        echo "ERROR: ${HELPER_DEST} still present"
+        exit 1
+    fi
+
+    if systemctl is-enabled --quiet "${UNIT_NAME}"; then
+        echo "ERROR: ${UNIT_NAME} is still enabled"
+        exit 1
+    fi
+
+    echo "Verified ${UNIT_NAME} is removed"
+}
+
+main "$@"

--- a/tests/integration/nvidia_tuned/fakes/rdma_topo
+++ b/tests/integration/nvidia_tuned/fakes/rdma_topo
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for the rdma_topo tool that ships in the OCI GB300 node image.
+#
+# FAKE_RDMA_TOPO_CHECK=pass  -> `check` succeeds
+# FAKE_RDMA_TOPO_CHECK=fail  -> `check` fails (the stock GB300 state); default
+# FAKE_RDMA_TOPO_CHECK=fix   -> `check` fails until write-grub-acs has run, then succeeds
+
+set -uo pipefail
+
+STATE_DIR="${FAKE_RDMA_TOPO_STATE:-/tmp/fake-rdma-topo}"
+GRUB_DROPIN="${FAKE_RDMA_TOPO_DROPIN:-/etc/default/grub.d/config-acs.cfg}"
+mkdir -p "${STATE_DIR}"
+
+echo "$*" >> "${STATE_DIR}/calls"
+
+case "${1:-}" in
+    check)
+        case "${FAKE_RDMA_TOPO_CHECK:-fail}" in
+            pass)
+                echo "PASS ACS for grace_rp 0008:00:00.0"
+                exit 0
+                ;;
+            fix)
+                if [[ -f "${STATE_DIR}/wrote-grub-acs" ]]; then
+                    echo "PASS ACS for grace_rp 0008:00:00.0"
+                    exit 0
+                fi
+                ;;
+        esac
+        echo "FAIL ACS for grace_rp 0008:00:00.0 has incorrect values 0011101 != xx111x0 (0x1d != 0x1c)" >&2
+        exit 1
+        ;;
+    write-grub-acs)
+        mkdir -p "$(dirname "${GRUB_DROPIN}")"
+        cat > "${GRUB_DROPIN}" <<'EOF'
+GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} pci=config_acs=101xxxx@0008:00:00.0;101xxxx@0009:00:00.0"
+EOF
+        touch "${STATE_DIR}/wrote-grub-acs"
+        echo "wrote ${GRUB_DROPIN}"
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/tests/integration/nvidia_tuned/fakes/rdma_topo
+++ b/tests/integration/nvidia_tuned/fakes/rdma_topo
@@ -22,7 +22,7 @@
 # FAKE_RDMA_TOPO_CHECK=fail  -> `check` fails (the stock GB300 state); default
 # FAKE_RDMA_TOPO_CHECK=fix   -> `check` fails until write-grub-acs has run, then succeeds
 
-set -uo pipefail
+set -euo pipefail
 
 STATE_DIR="${FAKE_RDMA_TOPO_STATE:-/tmp/fake-rdma-topo}"
 GRUB_DROPIN="${FAKE_RDMA_TOPO_DROPIN:-/etc/default/grub.d/config-acs.cfg}"
@@ -56,6 +56,10 @@ EOF
         echo "wrote ${GRUB_DROPIN}"
         exit 0
         ;;
+    *)
+        # Fail loudly rather than silently succeeding, so a script that grows a new
+        # rdma_topo subcommand cannot pass its tests without the double modelling it.
+        echo "fake rdma_topo: unsupported subcommand '${1:-}'" >&2
+        exit 64
+        ;;
 esac
-
-exit 0

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for systemctl. Records enable/start state under FAKE_SYSTEMCTL_STATE so a
+# check script run later in the same container observes what the install script did.
+#
+# Set FAKE_SYSTEMCTL_ENABLE_FAIL=1 to make `enable` fail.
+
+set -uo pipefail
+
+STATE_DIR="${FAKE_SYSTEMCTL_STATE:-/tmp/fake-systemctl}"
+mkdir -p "${STATE_DIR}"
+
+verb=""
+unit=""
+for arg in "$@"; do
+    case "${arg}" in
+        --*) continue ;;
+    esac
+    if [[ -z "${verb}" ]]; then
+        verb="${arg}"
+    elif [[ -z "${unit}" ]]; then
+        unit="${arg}"
+    fi
+done
+
+echo "${verb} ${unit}" >> "${STATE_DIR}/calls"
+
+case "${verb}" in
+    daemon-reload)
+        touch "${STATE_DIR}/daemon-reloaded"
+        ;;
+    enable)
+        [[ "${FAKE_SYSTEMCTL_ENABLE_FAIL:-0}" == "1" ]] && exit 1
+        touch "${STATE_DIR}/enabled.${unit}"
+        # `enable --now` also starts the unit.
+        for arg in "$@"; do
+            [[ "${arg}" == "--now" ]] && touch "${STATE_DIR}/active.${unit}"
+        done
+        ;;
+    disable)
+        rm -f "${STATE_DIR}/enabled.${unit}"
+        # `disable --now` also stops the unit.
+        for arg in "$@"; do
+            [[ "${arg}" == "--now" ]] && rm -f "${STATE_DIR}/active.${unit}"
+        done
+        ;;
+    start)
+        touch "${STATE_DIR}/active.${unit}"
+        ;;
+    stop)
+        rm -f "${STATE_DIR}/active.${unit}"
+        ;;
+    is-enabled)
+        if [[ -f "${STATE_DIR}/enabled.${unit}" ]]; then
+            echo "enabled"
+        else
+            echo "disabled"
+            exit 1
+        fi
+        ;;
+    is-active)
+        if [[ -f "${STATE_DIR}/active.${unit}" ]]; then
+            echo "active"
+        else
+            echo "inactive"
+            exit 3
+        fi
+        ;;
+    status)
+        echo "fake status for ${unit}"
+        ;;
+esac
+
+exit 0

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -60,7 +60,9 @@ case "${verb}" in
             [[ "${arg}" == "--now" ]] && rm -f "${STATE_DIR}/active.${unit}"
         done
         ;;
-    start)
+    start | restart)
+        # prepare_nvidia_profiles.sh restarts tuned after rewriting tuned-main.conf, so
+        # restart must be modelled or that script would trip the default branch below.
         touch "${STATE_DIR}/active.${unit}"
         ;;
     stop)

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -21,7 +21,7 @@
 #
 # Set FAKE_SYSTEMCTL_ENABLE_FAIL=1 to make `enable` fail.
 
-set -uo pipefail
+set -euo pipefail
 
 STATE_DIR="${FAKE_SYSTEMCTL_STATE:-/tmp/fake-systemctl}"
 mkdir -p "${STATE_DIR}"
@@ -84,6 +84,12 @@ case "${verb}" in
         ;;
     status)
         echo "fake status for ${unit}"
+        ;;
+    *)
+        # Fail loudly rather than silently succeeding. A double that returns 0 for an
+        # unmodelled verb would let a script appear to work while doing nothing.
+        echo "fake systemctl: unsupported command '${verb}' (unit '${unit}')" >&2
+        exit 64
         ;;
 esac
 

--- a/tests/integration/nvidia_tuned/fakes/update-grub
+++ b/tests/integration/nvidia_tuned/fakes/update-grub
@@ -19,7 +19,7 @@
 # Test double for update-grub. Records that it ran so tests can assert the bootloader
 # config was regenerated after the ACS drop-in was written.
 
-set -uo pipefail
+set -euo pipefail
 
 STATE_DIR="${FAKE_GRUB_STATE:-/tmp/fake-grub}"
 mkdir -p "${STATE_DIR}"

--- a/tests/integration/nvidia_tuned/fakes/update-grub
+++ b/tests/integration/nvidia_tuned/fakes/update-grub
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for update-grub. Records that it ran so tests can assert the bootloader
+# config was regenerated after the ACS drop-in was written.
+
+set -uo pipefail
+
+STATE_DIR="${FAKE_GRUB_STATE:-/tmp/fake-grub}"
+mkdir -p "${STATE_DIR}"
+touch "${STATE_DIR}/update-grub-ran"
+echo "Generating grub configuration file ..."
+exit 0

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -431,7 +431,7 @@ def test_wait_rdma_vfs_falls_back_on_a_bad_poll_interval(node):
 
 
 @pytest.mark.parametrize(
-    "name,value",
+    ("name", "value"),
     [
         ("EXPECTED_VFS", "abc"),
         ("TIMEOUT_SECS", "-5"),
@@ -501,6 +501,37 @@ def test_pcie_acs_config_check_accepts_a_pending_reboot(node):
     assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
     assert step(node, "configure_pcie_acs_check.sh", failing) == 0, output(node)
     assert said(node, "pending reboot"), output(node)
+
+
+@pytest.mark.parametrize(
+    ("dropin", "accepted"),
+    [
+        ('GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT pci=config_acs=1@0008:00:00.0"', True),
+        ("pci=config_acs=1@0008:00:00.0", True),
+        ("\tpci=config_acs=1@0008:00:00.0", True),
+        ("# pci=config_acs=1@0008:00:00.0", False),
+        ("  # pci=config_acs=1@0008:00:00.0", False),
+        ("# example only, nothing active here", False),
+    ],
+    ids=["assignment", "bare", "tab-indented", "comment", "indented-comment", "no-token"],
+)
+def test_pcie_acs_config_check_only_accepts_an_active_setting(node, dropin, accepted):
+    """A commented example must not satisfy the pre-reboot check, but indentation must.
+
+    Pins the matcher: a drop-in that contributes nothing to the kernel command line has
+    to fail here rather than surviving to a post-interrupt failure after the reboot.
+    """
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    assert sh(node, f"printf '%s\\n' {shell_quote(dropin)} > {ACS_DROPIN}") == 0
+
+    rc = step(node, "configure_pcie_acs_check.sh", {"FAKE_RDMA_TOPO_CHECK": "fail"})
+    if accepted:
+        assert rc == 0, output(node)
+        assert said(node, "pending reboot"), output(node)
+    else:
+        assert rc != 0, output(node)
+        assert said(node, "does not contain an active"), output(node)
 
 
 def test_pcie_acs_config_check_fails_when_nothing_was_written(node):

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -102,8 +102,9 @@ def node():
         tty=False,
         stdin_open=False,
     )
-    _wait_until_ready(runner)
+    # Inside the try so a readiness timeout still tears down the container and tempdir.
     try:
+        _wait_until_ready(runner)
         yield runner
     finally:
         runner.cleanup()
@@ -318,8 +319,22 @@ def test_rdma_vfs_ready_uninstall_is_idempotent_when_never_installed(node):
     configure(node, **OCI_GB300)
 
     assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
-    assert said(node, "nothing to do"), output(node)
     assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert step(node, "uninstall_rdma_vfs_ready_check.sh") == 0, output(node)
+
+
+def test_rdma_vfs_ready_uninstall_cleans_up_a_partial_install(node):
+    """A missing unit file must not short-circuit the disable; the symlink can outlive it."""
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    # Unit file gone but still enabled, which is what a half-torn-down host looks like.
+    assert sh(node, f"rm -f {UNIT_DEST}") == 0
+    assert exists(node, "/tmp/fake-systemctl/enabled.rdma-vfs-ready.service")
+
+    assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert not exists(node, "/tmp/fake-systemctl/enabled.rdma-vfs-ready.service")
+    assert not exists(node, HELPER_DEST)
     assert step(node, "uninstall_rdma_vfs_ready_check.sh") == 0, output(node)
 
 

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the nvidia-tuned host setup steps added for OCI GB300.
+
+Covers:
+- install_rdma_vfs_ready.sh, its config, post-interrupt, and uninstall checks
+- configure_pcie_acs.sh, its config and post-interrupt checks
+- the bundled wait-rdma-vfs.sh helper
+
+Both steps self-gate on bundled assets resolved from the service and accelerator
+configmaps, so the no-op path for every other service/accelerator pair is covered too.
+
+These steps do not depend on the OS, so they run against a single base image rather
+than the package TEST_MATRIX. Real systemctl, rdma_topo, and update-grub are replaced
+by the test doubles in fakes/.
+
+Assertions go through exit codes rather than captured text: a step's output is written
+to a file in the container and matched there with grep. The container exec API returns
+exit codes reliably but its streamed output is occasionally empty for a short-lived
+exec under parallel load, which otherwise shows up as a flaky text assertion.
+"""
+
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.docker_test import DockerTestRunner
+
+BASE_IMAGE = "ubuntu:24.04"
+
+FAKES_DIR = Path(__file__).resolve().parent / "fakes"
+FAKE_BIN = "/fakes"
+OUTPUT_FILE = "/tmp/step-output"
+
+UNIT_DEST = "/etc/systemd/system/rdma-vfs-ready.service"
+HELPER_DEST = "/usr/local/sbin/wait-rdma-vfs.sh"
+ACS_DROPIN = "/etc/default/grub.d/config-acs.cfg"
+SYSTEMCTL_CALLS = "/tmp/fake-systemctl/calls"
+
+BUNDLED_DIR = "/skyhook-package/profiles/service/oci/rdma-vfs-ready-gb300"
+BUNDLED_UNIT = f"{BUNDLED_DIR}/rdma-vfs-ready.service"
+BUNDLED_HELPER = f"{BUNDLED_DIR}/wait-rdma-vfs.sh"
+
+STEP_ENV = {
+    "SKYHOOK_DIR": "/skyhook-package",
+    "STEP_ROOT": "/skyhook-package/skyhook_dir",
+    "PATH": f"{FAKE_BIN}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "FAKE_SYSTEMCTL_STATE": "/tmp/fake-systemctl",
+    "FAKE_RDMA_TOPO_STATE": "/tmp/fake-rdma-topo",
+    "FAKE_GRUB_STATE": "/tmp/fake-grub",
+}
+
+
+@pytest.fixture
+def node():
+    """A running container with the package mounted and the fakes ahead of PATH."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=BASE_IMAGE)
+    temp_dir = Path(tempfile.mkdtemp(prefix="skyhook-test-"))
+    runner.temp_dir = str(temp_dir)
+
+    package_dir = temp_dir / "skyhook-package"
+    shutil.copytree(runner._package_path, package_dir, dirs_exist_ok=True)
+    for sh_file in package_dir.rglob("*.sh"):
+        sh_file.chmod(0o755)
+    (package_dir / "configmaps").mkdir(parents=True, exist_ok=True)
+    (package_dir / "node-metadata").mkdir(parents=True, exist_ok=True)
+
+    fakes_dir = temp_dir / "fakes"
+    shutil.copytree(FAKES_DIR, fakes_dir)
+    for fake in fakes_dir.iterdir():
+        fake.chmod(0o755)
+
+    runner.container = runner.client.containers.run(
+        BASE_IMAGE,
+        command=["/bin/bash", "-c", "tail -f /dev/null"],
+        detach=True,
+        volumes={
+            str(package_dir): {"bind": "/skyhook-package", "mode": "rw"},
+            str(fakes_dir): {"bind": FAKE_BIN, "mode": "ro"},
+        },
+        remove=False,
+        tty=False,
+        stdin_open=False,
+    )
+    _wait_until_ready(runner)
+    try:
+        yield runner
+    finally:
+        runner.cleanup()
+
+
+def _wait_until_ready(runner: DockerTestRunner, timeout: float = 60.0):
+    """Block until the container accepts execs and both bind mounts are visible."""
+    probe = "test -f /skyhook-package/config.json && test -x /fakes/systemctl"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if runner.container.exec_run(["/bin/bash", "-c", probe]).exit_code == 0:
+                return
+        except Exception:  # container is not accepting execs yet
+            pass
+        time.sleep(0.25)
+    raise RuntimeError("container never became ready")
+
+
+# ---------------------------------------------------------------------------
+# Container helpers. Every assertion resolves to an exit code.
+# ---------------------------------------------------------------------------
+
+
+def sh(node: DockerTestRunner, command: str, env: dict = None) -> int:
+    """Run a shell command in the container and return its exit code."""
+    return node.container.exec_run(
+        ["/bin/bash", "-c", command], workdir="/", environment=env or {}
+    ).exit_code
+
+
+def step(node: DockerTestRunner, script: str, env: dict = None) -> int:
+    """Run a lifecycle step, tee its output to OUTPUT_FILE, and return its exit code."""
+    step_env = dict(STEP_ENV)
+    if env:
+        step_env.update(env)
+    return node.container.exec_run(
+        [
+            "/bin/bash",
+            "-c",
+            f"/skyhook-package/skyhook_dir/{script} > {OUTPUT_FILE} 2>&1",
+        ],
+        workdir="/skyhook-package",
+        environment=step_env,
+    ).exit_code
+
+
+def said(node: DockerTestRunner, text: str) -> bool:
+    """True when the last step's output contained text."""
+    return sh(node, f"grep -qF {shell_quote(text)} {OUTPUT_FILE}") == 0
+
+
+def output(node: DockerTestRunner) -> str:
+    """Best-effort read of the last step's output, for assertion messages only."""
+    result = node.container.exec_run(["cat", OUTPUT_FILE])
+    return result.output.decode("utf-8", errors="replace")
+
+
+def shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def exists(node: DockerTestRunner, path: str) -> bool:
+    return sh(node, f"test -e {path}") == 0
+
+
+def contains(node: DockerTestRunner, path: str, text: str) -> bool:
+    return sh(node, f"grep -qF {shell_quote(text)} {path}") == 0
+
+
+def same(node: DockerTestRunner, left: str, right: str) -> bool:
+    return sh(node, f"cmp -s {left} {right}") == 0
+
+
+def configure(node: DockerTestRunner, **configmaps):
+    """Replace the container's configmaps."""
+    cmds = ["rm -rf /skyhook-package/configmaps", "mkdir -p /skyhook-package/configmaps"]
+    for key, value in configmaps.items():
+        cmds.append(
+            f"printf '%s' {shell_quote(value)} > /skyhook-package/configmaps/{key}"
+        )
+    assert sh(node, " && ".join(cmds)) == 0
+
+
+OCI_GB300 = {"accelerator": "gb300", "service": "oci"}
+OTHER_SHAPES = [
+    {"accelerator": "h100", "service": "eks"},
+    {"accelerator": "gb200", "service": "oci"},
+    {"accelerator": "gb300"},
+]
+OTHER_SHAPE_IDS = ["eks-h100", "oci-gb200", "gb300-no-service"]
+
+
+# ---------------------------------------------------------------------------
+# install_rdma_vfs_ready.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "configmaps",
+    OTHER_SHAPES + [{"accelerator": "gb300", "service": ""}],
+    ids=OTHER_SHAPE_IDS + ["gb300-empty-service"],
+)
+def test_rdma_vfs_ready_is_a_noop_without_bundled_assets(node, configmaps):
+    """Only service/accelerator pairs that ship the unit get it installed."""
+    configure(node, **configmaps)
+
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, HELPER_DEST)
+
+    assert step(node, "install_rdma_vfs_ready_check.sh") == 0, output(node)
+    assert said(node, "nothing to verify"), output(node)
+
+    assert step(node, "post_interrupt_rdma_vfs_ready_check.sh") == 0, output(node)
+    assert said(node, "nothing to verify"), output(node)
+
+
+def test_rdma_vfs_ready_installs_and_enables_for_oci_gb300(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+    assert same(node, BUNDLED_UNIT, UNIT_DEST)
+    assert same(node, BUNDLED_HELPER, HELPER_DEST)
+    assert sh(node, f"test -x {HELPER_DEST}") == 0
+    assert contains(node, SYSTEMCTL_CALLS, "daemon-reload")
+    assert contains(node, SYSTEMCTL_CALLS, "enable rdma-vfs-ready.service")
+
+    # Enabled but not started: the unit is a boot-ordering gate.
+    assert not exists(node, "/tmp/fake-systemctl/active.rdma-vfs-ready.service")
+
+    assert step(node, "install_rdma_vfs_ready_check.sh") == 0, output(node)
+    assert said(node, "installed and enabled"), output(node)
+
+
+def test_rdma_vfs_ready_unit_orders_before_kubelet(node):
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    for line in (
+        "Before=kubelet.service",
+        "After=snap.oracle-cloud-agent.oracle-cloud-agent.service",
+        "Type=oneshot",
+        "RemainAfterExit=true",
+        f"ExecStart={HELPER_DEST}",
+    ):
+        assert contains(node, UNIT_DEST, line), f"missing {line!r} in unit"
+
+
+def test_rdma_vfs_ready_install_is_idempotent(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+    assert step(node, "install_rdma_vfs_ready_check.sh") == 0, output(node)
+
+
+def test_rdma_vfs_ready_check_fails_when_unit_missing(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "install_rdma_vfs_ready_check.sh") != 0
+    assert said(node, "missing"), output(node)
+
+
+def test_rdma_vfs_ready_check_fails_when_unit_edited_on_host(node):
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+    assert sh(node, f"echo '# drift' >> {UNIT_DEST}") == 0
+
+    assert step(node, "install_rdma_vfs_ready_check.sh") != 0
+    assert said(node, "does not match bundled"), output(node)
+
+
+def test_rdma_vfs_ready_post_interrupt_check_requires_the_unit_to_have_run(node):
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    # Enabled but never started, which is what a missed boot looks like.
+    assert step(node, "post_interrupt_rdma_vfs_ready_check.sh") != 0
+    assert said(node, "did not run during boot"), output(node)
+
+    # Simulate the unit running during the post-reboot boot.
+    assert sh(node, "touch /tmp/fake-systemctl/active.rdma-vfs-ready.service") == 0
+    assert step(node, "post_interrupt_rdma_vfs_ready_check.sh") == 0, output(node)
+    assert said(node, "ran during boot"), output(node)
+
+
+def test_rdma_vfs_ready_uninstall_removes_the_gate(node):
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, HELPER_DEST)
+    assert contains(node, SYSTEMCTL_CALLS, "disable rdma-vfs-ready.service")
+    assert step(node, "uninstall_rdma_vfs_ready_check.sh") == 0, output(node)
+
+
+def test_rdma_vfs_ready_uninstall_runs_regardless_of_configmaps(node):
+    """Uninstall keys on host state, so it cleans up after changed configmaps too."""
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    configure(node, accelerator="h100", service="eks")
+    assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert not exists(node, UNIT_DEST)
+    assert step(node, "uninstall_rdma_vfs_ready_check.sh") == 0, output(node)
+
+
+def test_rdma_vfs_ready_uninstall_is_idempotent_when_never_installed(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert step(node, "uninstall_rdma_vfs_ready.sh") == 0, output(node)
+    assert step(node, "uninstall_rdma_vfs_ready_check.sh") == 0, output(node)
+
+
+def test_rdma_vfs_ready_uninstall_check_fails_while_the_unit_remains(node):
+    configure(node, **OCI_GB300)
+    assert step(node, "install_rdma_vfs_ready.sh") == 0, output(node)
+
+    assert step(node, "uninstall_rdma_vfs_ready_check.sh") != 0
+    assert said(node, "still present"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# wait-rdma-vfs.sh
+# ---------------------------------------------------------------------------
+
+
+def stage_netdevs(node: DockerTestRunner, vfs: int, plain: int = 2):
+    """Build a fake /sys/class/net tree with `vfs` VFs and `plain` non-VF devices."""
+    cmds = ["rm -rf /tmp/netdevs", "mkdir -p /tmp/netdevs"]
+    for i in range(plain):
+        cmds.append(f"mkdir -p /tmp/netdevs/eth{i}/device")
+    for i in range(vfs):
+        # A VF netdev is identified by a physfn link back to its physical function.
+        cmds.append(f"mkdir -p /tmp/netdevs/rdma{i}/device")
+        cmds.append(f"ln -sfn /tmp/netdevs/eth0/device /tmp/netdevs/rdma{i}/device/physfn")
+    assert sh(node, " && ".join(cmds)) == 0
+
+
+def wait_helper(node: DockerTestRunner, **env) -> int:
+    helper_env = {"SYS_CLASS_NET": "/tmp/netdevs", "POLL_INTERVAL_SECS": "1"}
+    helper_env.update({k: str(v) for k, v in env.items()})
+    return sh(node, f"{BUNDLED_HELPER} > {OUTPUT_FILE} 2>&1", env=helper_env)
+
+
+def test_wait_rdma_vfs_returns_once_all_vfs_are_present(node):
+    stage_netdevs(node, vfs=4)
+
+    assert wait_helper(node, EXPECTED_VFS=4, TIMEOUT_SECS=10) == 0, output(node)
+    assert said(node, "Found 4 RDMA VFs"), output(node)
+
+
+def test_wait_rdma_vfs_releases_early_when_a_partial_count_settles(node):
+    """A dead CX8 leaves fewer VFs than expected; the node must still join."""
+    stage_netdevs(node, vfs=3)
+
+    rc = wait_helper(node, EXPECTED_VFS=4, TIMEOUT_SECS=60, STABLE_POLLS=3)
+    assert rc == 0, output(node)
+    assert said(node, "settled at 3"), output(node)
+
+
+def test_wait_rdma_vfs_exits_zero_when_no_vfs_ever_appear(node):
+    """The helper must never block a node from joining the cluster."""
+    stage_netdevs(node, vfs=0)
+
+    assert wait_helper(node, EXPECTED_VFS=4, TIMEOUT_SECS=4) == 0, output(node)
+    assert said(node, "Timed out"), output(node)
+
+
+def test_wait_rdma_vfs_ignores_non_vf_interfaces(node):
+    """Only netdevs with a physfn link count as VFs."""
+    stage_netdevs(node, vfs=0, plain=6)
+
+    assert wait_helper(node, EXPECTED_VFS=1, TIMEOUT_SECS=4) == 0, output(node)
+    assert said(node, "with 0 RDMA VFs"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# configure_pcie_acs.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("configmaps", OTHER_SHAPES, ids=OTHER_SHAPE_IDS)
+def test_pcie_acs_is_a_noop_without_the_opt_in_marker(node, configmaps):
+    configure(node, **configmaps)
+
+    assert step(node, "configure_pcie_acs.sh") == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, ACS_DROPIN)
+    assert not exists(node, "/tmp/fake-rdma-topo/calls")
+
+    for check in ("configure_pcie_acs_check.sh", "post_interrupt_pcie_acs_check.sh"):
+        assert step(node, check) == 0, output(node)
+        assert said(node, "nothing to verify"), output(node)
+
+
+def test_pcie_acs_does_nothing_when_the_node_is_already_correct(node):
+    configure(node, **OCI_GB300)
+    passing = {"FAKE_RDMA_TOPO_CHECK": "pass"}
+
+    assert step(node, "configure_pcie_acs.sh", passing) == 0, output(node)
+    assert said(node, "already correct"), output(node)
+    assert not exists(node, ACS_DROPIN)
+
+    assert step(node, "configure_pcie_acs_check.sh", passing) == 0, output(node)
+    assert said(node, "values are correct"), output(node)
+
+
+def test_pcie_acs_writes_the_bootloader_dropin_when_check_fails(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_pcie_acs.sh", {"FAKE_RDMA_TOPO_CHECK": "fail"}) == 0
+    assert said(node, "reboot is required"), output(node)
+    assert contains(node, ACS_DROPIN, "config_acs")
+    assert contains(node, "/tmp/fake-rdma-topo/calls", "write-grub-acs")
+    assert exists(node, "/tmp/fake-grub/update-grub-ran")
+
+
+def test_pcie_acs_config_check_accepts_a_pending_reboot(node):
+    """Before the reboot, rdma_topo check still fails; the drop-in is the evidence."""
+    configure(node, **OCI_GB300)
+    failing = {"FAKE_RDMA_TOPO_CHECK": "fail"}
+
+    assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
+    assert step(node, "configure_pcie_acs_check.sh", failing) == 0, output(node)
+    assert said(node, "pending reboot"), output(node)
+
+
+def test_pcie_acs_config_check_fails_when_nothing_was_written(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_pcie_acs_check.sh", {"FAKE_RDMA_TOPO_CHECK": "fail"}) != 0
+    assert said(node, "no bootloader drop-in"), output(node)
+
+
+def test_pcie_acs_is_idempotent_across_config_passes(node):
+    """Re-running before the reboot regenerates the same drop-in without erroring."""
+    configure(node, **OCI_GB300)
+    failing = {"FAKE_RDMA_TOPO_CHECK": "fail"}
+
+    assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
+    assert sh(node, f"cp {ACS_DROPIN} /tmp/dropin.first") == 0
+    assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
+
+    assert same(node, "/tmp/dropin.first", ACS_DROPIN)
+
+
+def test_pcie_acs_fails_when_rdma_topo_is_missing(node):
+    """rdma_topo ships in the node image for this shape; its absence is a real failure."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_pcie_acs.sh", {"RDMA_TOPO_BIN": "rdma_topo_absent"}) != 0
+    assert said(node, "not found"), output(node)
+
+
+def test_pcie_acs_post_interrupt_check_requires_acs_to_be_live(node):
+    configure(node, **OCI_GB300)
+    fixable = {"FAKE_RDMA_TOPO_CHECK": "fix"}
+
+    # Pre-reboot: the drop-in exists but the running kernel is unchanged.
+    assert step(node, "configure_pcie_acs.sh", fixable) == 0, output(node)
+    assert sh(node, "rm -f /tmp/fake-rdma-topo/wrote-grub-acs") == 0
+    assert step(node, "post_interrupt_pcie_acs_check.sh", fixable) != 0
+    assert said(node, "did not take effect on this node"), output(node)
+
+    # Post-reboot: the corrected values are live.
+    assert sh(node, "touch /tmp/fake-rdma-topo/wrote-grub-acs") == 0
+    assert step(node, "post_interrupt_pcie_acs_check.sh", fixable) == 0, output(node)
+    assert said(node, "correct after reboot"), output(node)
+
+
+def test_pcie_acs_failure_message_names_cause_impact_and_remedy(node):
+    """Whoever investigates the failure must not need to read the source to act."""
+    configure(node, **OCI_GB300)
+    failing = {"FAKE_RDMA_TOPO_CHECK": "fail"}
+
+    assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
+    assert step(node, "post_interrupt_pcie_acs_check.sh", failing) != 0
+
+    # Cause: the drop-in never reached the booted kernel command line.
+    assert said(node, "no config_acs argument"), output(node)
+    # Impact: what the operator loses, and what workloads still need.
+    assert said(node, "nvidia_peermem"), output(node)
+    assert said(node, "NCCL_DMABUF_ENABLE=0"), output(node)
+    # Remedy: the documented opt-out.
+    assert said(node, "CONFIGURE_PCIE_ACS=false"), output(node)
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+def test_pcie_acs_can_be_switched_off_by_the_operator(node, value):
+    """CONFIGURE_PCIE_ACS is the escape hatch for kernels that ignore pci=config_acs=."""
+    configure(node, **OCI_GB300)
+    off = {"CONFIGURE_PCIE_ACS": value, "FAKE_RDMA_TOPO_CHECK": "fail"}
+
+    assert step(node, "configure_pcie_acs.sh", off) == 0, output(node)
+    assert said(node, "switched off"), output(node)
+    assert not exists(node, ACS_DROPIN)
+    assert not exists(node, "/tmp/fake-rdma-topo/calls")
+
+    # Both checks stand down too, so a switched-off node never fails post-interrupt.
+    for check in ("configure_pcie_acs_check.sh", "post_interrupt_pcie_acs_check.sh"):
+        assert step(node, check, off) == 0, output(node)
+        assert said(node, "switched off"), output(node)
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "", "yes"])
+def test_pcie_acs_stays_on_for_any_non_falsey_value(node, value):
+    configure(node, **OCI_GB300)
+
+    rc = step(node, "configure_pcie_acs.sh", {"CONFIGURE_PCIE_ACS": value, "FAKE_RDMA_TOPO_CHECK": "fail"})
+    assert rc == 0, output(node)
+    assert said(node, "reboot is required"), output(node)
+    assert exists(node, ACS_DROPIN)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -90,20 +90,22 @@ def node():
     for fake in fakes_dir.iterdir():
         fake.chmod(0o755)
 
-    runner.container = runner.client.containers.run(
-        BASE_IMAGE,
-        command=["/bin/bash", "-c", "tail -f /dev/null"],
-        detach=True,
-        volumes={
-            str(package_dir): {"bind": "/skyhook-package", "mode": "rw"},
-            str(fakes_dir): {"bind": FAKE_BIN, "mode": "ro"},
-        },
-        remove=False,
-        tty=False,
-        stdin_open=False,
-    )
-    # Inside the try so a readiness timeout still tears down the container and tempdir.
+    # The guard opens before container creation, not after: if containers.run raises,
+    # the temp dir would otherwise leak, and if readiness times out the container would.
+    # runner.cleanup() tolerates a container that was never assigned.
     try:
+        runner.container = runner.client.containers.run(
+            BASE_IMAGE,
+            command=["/bin/bash", "-c", "tail -f /dev/null"],
+            detach=True,
+            volumes={
+                str(package_dir): {"bind": "/skyhook-package", "mode": "rw"},
+                str(fakes_dir): {"bind": FAKE_BIN, "mode": "ro"},
+            },
+            remove=False,
+            tty=False,
+            stdin_open=False,
+        )
         _wait_until_ready(runner)
         yield runner
     finally:
@@ -399,6 +401,55 @@ def test_wait_rdma_vfs_ignores_non_vf_interfaces(node):
 
     assert wait_helper(node, EXPECTED_VFS=1, TIMEOUT_SECS=4) == 0, output(node)
     assert said(node, "with 0 RDMA VFs"), output(node)
+
+
+def test_wait_rdma_vfs_aborts_on_error_but_still_releases_kubelet(node):
+    """errexit must reach inside main, and an abort must still exit 0.
+
+    Bash suppresses errexit throughout a function invoked as a condition, so calling
+    main via `if ! main` would let it run past a failed command instead of aborting.
+    Pointing SYS_CLASS_NET at a path that cannot be globbed makes count_vfs fail.
+    """
+    stage_netdevs(node, vfs=0)
+    assert sh(node, "rm -rf /tmp/netdevs") == 0
+
+    # A non-existent tree makes the glob literal, so the physfn test fails on a path
+    # containing '*', and the run aborts rather than polling to the timeout.
+    rc = wait_helper(
+        node, SYS_CLASS_NET="/tmp/does-not-exist", EXPECTED_VFS=4, TIMEOUT_SECS=4
+    )
+    assert rc == 0, output(node)
+
+
+def test_wait_rdma_vfs_falls_back_on_a_bad_poll_interval(node):
+    """POLL_INTERVAL_SECS=0 would stop elapsed advancing and busy-spin until systemd."""
+    stage_netdevs(node, vfs=0)
+
+    rc = wait_helper(node, EXPECTED_VFS=4, TIMEOUT_SECS=4, POLL_INTERVAL_SECS=0)
+    assert rc == 0, output(node)
+    assert said(node, "POLL_INTERVAL_SECS='0' is not a positive integer"), output(node)
+
+
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("EXPECTED_VFS", "abc"),
+        ("TIMEOUT_SECS", "-5"),
+        ("STABLE_POLLS", "0"),
+        ("POLL_INTERVAL_SECS", "1.5"),
+    ],
+)
+def test_wait_rdma_vfs_rejects_non_positive_integer_overrides(node, name, value):
+    """Non-numeric, negative, zero, and fractional overrides all fall back to defaults.
+
+    An empty value is deliberately not covered: `${VAR:-default}` already substitutes
+    the default for an empty string, so it never reaches the validator.
+    """
+    stage_netdevs(node, vfs=4)
+
+    rc = wait_helper(node, **{"EXPECTED_VFS": "4", "TIMEOUT_SECS": "6", name: value})
+    assert rc == 0, output(node)
+    assert said(node, f"{name}='{value}' is not a positive integer"), output(node)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -511,9 +511,18 @@ def test_pcie_acs_config_check_accepts_a_pending_reboot(node):
         ("\tpci=config_acs=1@0008:00:00.0", True),
         ("# pci=config_acs=1@0008:00:00.0", False),
         ("  # pci=config_acs=1@0008:00:00.0", False),
+        ('GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT" # pci=config_acs=1', False),
         ("# example only, nothing active here", False),
     ],
-    ids=["assignment", "bare", "tab-indented", "comment", "indented-comment", "no-token"],
+    ids=[
+        "assignment",
+        "bare",
+        "tab-indented",
+        "comment",
+        "indented-comment",
+        "inline-comment",
+        "no-token",
+    ],
 )
 def test_pcie_acs_config_check_only_accepts_an_active_setting(node, dropin, accepted):
     """A commented example must not satisfy the pre-reboot check, but indentation must.


### PR DESCRIPTION
## Description

Adds two host-level fixes for GB300 nodes on OCI, both validated in a live GB300
cluster. They land as `config` steps scoped to the same `service=oci`,
`accelerator=gb300` shape the RDMA IPv6 work in #108 already targets.

### 1. PCIe ACS correction

GB300 nodes ship with ACS enabled on the RoCE NIC root ports, which blocks
peer-to-peer DMA. `rdma_topo check` fails on every stock node:

```
FAIL ACS for grace_rp 0008:00:00.0 has incorrect values 0011101 != xx111x0 (0x1d != 0x1c)
```

The new `configure-pcie-acs` step runs the node's own `rdma_topo` tool to generate a
`pci=config_acs=...` bootloader drop-in, then regenerates the grub config.

Measured on 2 nodes x 4 GPUs, `all_reduce_perf`, RoCE only:

| Configuration | Peak busbw |
|---|---|
| ACS broken, peermem, 6.8 | 360.79 GB/s |
| ACS fixed, DMA-BUF, 6.14 | 425.58 GB/s |
| ACS fixed, DMA-BUF, 6.17 | 430.68 GB/s |

DMA-BUF works once ACS is correct: `mlx5dv_reg_dmabuf_mr` previously failed with
ENOTSUPP on both 6.8 and 6.17, and there were zero failures after the fix. So
`nvidia_peermem` is no longer required and `NCCL_DMABUF_ENABLE=0` can be dropped on nodes
where the correction takes effect (see the switch below). Kernel version was not the
variable in the measurements above; 6.14 and 6.17 are within 1% of each other.

The generated values hardcode local PCI addresses (`0008/0009/0018/0019:...`) valid only
for BM.GPU.GB300.4, so they are produced per node rather than baked into the image. The
tool itself is shape-agnostic and idempotent.

The correction only takes effect on kernels that honour `pci=config_acs=`. Rather than
probe kernel versions, the step is switchable: `CONFIGURE_PCIE_ACS` defaults to on, and
setting it to `false` skips the correction and both of its checks. On a node that cannot
support it, the drop-in would otherwise be written but ignored, and the post-interrupt
check would fail the node. `nvidia_peermem` and `NCCL_DMABUF_ENABLE=0` remain required
wherever the correction is off or ineffective.

### 2. RDMA VF boot gate

`network-operator-sriov-device-plugin` enumerates PCI devices once at startup and never
rescans, but the Oracle Cloud Agent creates the RDMA VFs roughly 70 seconds after boot.
The plugin therefore starts first, finds nothing, and the node advertises
`nvidia.com/mlnxnics: 0` permanently until the pod is deleted by hand.

This is not fixable through `NicClusterPolicy`: `sriovDevicePlugin` exposes only
config/image/resources/useCdi with no pod-spec extensibility, and the DaemonSet is owned
by NicClusterPolicy rather than Helm. NFD labels (`network-sriov.configured`) are useless
as a gate because node labels persist across reboot, so a stale `true` is present before
the VFs exist.

The new `install-rdma-vfs-ready` step installs a `rdma-vfs-ready.service` unit that
orders before `kubelet.service` and waits for the VFs to appear. Measured wait on a real
node was 72s; the unit blocks up to 300s. The wait **always exits 0**, including on
timeout and on a partial VF count that has stopped moving, so it can never strand a node
outside the cluster. This is deliberate: compare `lustre-modules-setup.service`, which
sits `Before=oke-init.service` and strands nodes when Lustre fails to build.

## Changes

**Two new `config` steps**, each self-gating on a bundled asset resolved from the
`service` and `accelerator` configmaps. This is the same idiom `write_nccl_topo.sh`
introduced in #108, so both steps are no-ops for any pair that ships nothing:

| Step | Asset that opts a pair in |
|---|---|
| `install-rdma-vfs-ready` | `profiles/service/<service>/rdma-vfs-ready-<accelerator>/` |
| `configure-pcie-acs` | `profiles/service/<service>/pcie-acs-<accelerator>.enabled` |

Only `oci` + `gb300` ships either today. `eks`, `aks`, and `bcm` are unaffected.

**One new env var**, `CONFIGURE_PCIE_ACS` (default `true`). Setting it to a falsey value
(`false`, `0`, `no`, `off`, any case) skips the ACS step and both of its checks. This is
the escape hatch for nodes whose kernel ignores `pci=config_acs=`. It does not affect the
VF gate, and it does not remove the need for the reboot interrupt.

**Lifecycle wiring** in `config.json` (version bumped to `0.6.0`):

- `config`: `install-rdma-vfs-ready`, `configure-pcie-acs`
- `config-check`: the matching checks, both of which tolerate a pending reboot
- `post-interrupt-check`: assert the ACS values are live and that the VF gate ran during
  boot
- `uninstall` / `uninstall-check`: remove the unit and its helper, and verify removal

`configure-pcie-acs` is the only new step with `idempotence: false`. It must re-run every
config pass because `rdma_topo check` reads live kernel state and keeps failing between
the grub write and the reboot; re-running `write-grub-acs` in that window regenerates the
same drop-in.

**One line in `prepare_nvidia_profiles.sh`** skips `*.enabled` when sweeping service
files into the tuned profile dir, so the opt-in marker is not copied somewhere tuned
would try to read it.

**Docs**: README gains the new assets in the directory tree, the host setup steps in
"How It Works", an updated OCI example, post-reboot verification commands, and a
corrected version line (it still said 0.3.0). RELEASE_NOTES gains a `0.6.0` section
carrying the upgrade note below.

## Notes for reviewers

- **This makes `service: oci` + `accelerator: gb300` require a reboot, which 0.5.0
  explicitly did not.** Both new settings only take effect at boot, and the
  post-interrupt checks fail if the node has not rebooted, so
  `interrupt: {type: reboot}` must be added to the custom resource before rolling 0.6.0
  out to those nodes. This stays true with `CONFIGURE_PCIE_ACS=false`, because the VF
  gate is a boot-ordering unit. The tuned profile chain itself still carries no
  `[bootloader]` stanza and still applies live; the reboot is for the host-level steps.
  Called out as an upgrade note in `RELEASE_NOTES.md`.
- **ACS is default-on and its post-interrupt check is fatal.** A node that requests the
  correction and does not get it fails post-interrupt rather than silently running
  degraded. The failure message is self-contained: it names the cause (drop-in absent
  from the booted cmdline, or present and ignored), the cost (roughly 15% RDMA
  throughput, no DMA-BUF, `nvidia_peermem` and `NCCL_DMABUF_ENABLE=0` still needed), and
  the remedy (`CONFIGURE_PCIE_ACS=false`). The paired config-check is deliberately
  stricter about a different thing: it fails when the drop-in was not written at all,
  because that is the package not doing its job rather than an environment mismatch.
- **The uninstall step is scoped to the systemd unit only.** The PCIe ACS bootloader
  drop-in is deliberately left in place: it corrects a hardware misconfiguration on the
  node rather than installing package state, reverting it would degrade RDMA performance,
  and it would not take effect until another reboot. Documented rather than silent. Happy
  to change this if reviewers would rather uninstall be a full revert.
- **`configure-pcie-acs` hard-fails when `rdma_topo` is absent** rather than skipping. The
  tool ships in the node image for this shape, so its absence means the node is not what
  the package thinks it is. `CONFIGURE_PCIE_ACS=false` is the way to run without it.
- **The VF gate is enabled but not started at config time**, following `bind-mount`'s
  precedent: activation happens through the reboot interrupt and `post-interrupt-check`
  is the gate. Starting it on a running node would be a no-op anyway.
- **`EXPECTED_VFS` defaults to 4** (a healthy BM.GPU.GB300.4). It and the timeout,
  poll interval, and stable-poll count are all env-overridable on the unit.
- The unit orders `Before=kubelet.service` only. Unlike `bind-mount` it does not also
  name `snap.kubelet-eks.daemon.service`, since this is OCI specific.

## Testing

Added `tests/integration/nvidia_tuned/test_host_setup.py`: 38 tests covering both steps'
install, check, post-interrupt, and uninstall paths, the no-op gating for other
service/accelerator pairs, the `CONFIGURE_PCIE_ACS` switch in both directions, the
content of the ACS failure message (cause, impact, remedy), and the wait helper's four
release paths (full count, settled partial count, timeout, non-VF interfaces ignored).
Real `systemctl`, `rdma_topo`, and `update-grub` are replaced by test doubles in
`fakes/`, following the `bind_mount` `fakes/` pattern.

| Check | Result |
|---|---|
| New suite, 38 tests, at `-n 4` | 38/38 |
| `shellcheck` on all new scripts and fakes | clean |
| `make license-check` | pass |
| `make validate-inherited PACKAGE=nvidia-tuned` | pass (schema, step files, exec bits) |

Assertions in the new suite resolve to exit codes rather than captured text: each step's
output is written to a file in the container and matched there with `grep`. An earlier
version that matched text in Python was flaky roughly 1 run in 3, because the container
exec API intermittently returns empty output for a short-lived exec under parallel load
while the exit code stays correct. This is contained entirely to the new test file;
`tests/helpers/docker_test.py`, `tests/conftest.py`, and the existing
`test_prepare_nvidia_profiles.py` are untouched.

Two gaps worth stating plainly:

- The one-line `prepare_nvidia_profiles.sh` change has no test asserting it. Deleting
  that line fails nothing; the marker would just be copied into the tuned profile dir as
  harmless clutter. Happy to add the assertion if wanted.
- Local verification used **podman**, not Docker. CI is the source of truth for the
  Docker path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.