### PR TITLE
feat(nvidia-tuned): run DOCA Spectrum-X congestion control on OCI GB300

### DIFF
--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -81,9 +81,12 @@ profiles/
         ├── nvidia-gb300-performance.conf   # Re-roots gb300 onto the bootloader-free base
         ├── nccl-topo-gb300.xml  # Installed to ${TOPO_PATH} by the write-nccl-topo config step
         ├── pcie-acs-gb300.enabled          # Opts gb300 in to the configure-pcie-acs config step
-        └── rdma-vfs-ready-gb300/           # Installed by the install-rdma-vfs-ready config step
-            ├── rdma-vfs-ready.service
-            └── wait-rdma-vfs.sh
+        ├── rdma-vfs-ready-gb300/           # Installed by the install-rdma-vfs-ready config step
+        │   ├── rdma-vfs-ready.service
+        │   └── wait-rdma-vfs.sh
+        └── spcx-cc-gb300/                  # Installed by the configure-spcx-cc config step
+            ├── doca-spcx-cc@.service
+            └── 99-doca-spcx-cc.rules
 ```
 
 Note: Profiles are stored in `profiles/` (not `root_dir/`) to avoid polluting the host filesystem during package extraction. The prepare scripts explicitly copy profiles to the appropriate tuned directories.
@@ -108,6 +111,8 @@ Note: Profiles are stored in `profiles/` (not `root_dir/`) to avoid polluting th
      `profiles/service/{service}/rdma-vfs-ready-{accelerator}/`
    - `configure-pcie-acs` runs the node's `rdma_topo` tool when
      `profiles/service/{service}/pcie-acs-{accelerator}.enabled` is present
+   - `configure-spcx-cc` installs the DOCA Spectrum-X congestion control template unit
+     and udev rule from `profiles/service/{service}/spcx-cc-{accelerator}/`
 
 3. **Config stage**: The inherited `tuned` package applies the configured profile
 
@@ -231,7 +236,7 @@ spec:
         service: aks
 ```
 
-**OCI tuning** (GB300 on OCI: NCCL topology file, PCIe ACS correction, RDMA VF boot gate):
+**OCI tuning** (GB300 on OCI: NCCL topology, PCIe ACS, RDMA VF gate, congestion control):
 
 ```yaml
 apiVersion: skyhook.nvidia.com/v1alpha1
@@ -245,7 +250,7 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: 0.6.0
+      version: 0.7.0
       interrupt:
         type: reboot
       env:
@@ -255,6 +260,15 @@ spec:
         intent: performance
         accelerator: gb300
         service: oci
+        spcx_cc: "on"
+      configInterrupts:
+        spcx_cc:
+          type: service
+          services:
+            - doca-spcx-cc@mlx5_bond_0
+            - doca-spcx-cc@mlx5_bond_1
+            - doca-spcx-cc@mlx5_bond_2
+            - doca-spcx-cc@mlx5_bond_3
 ```
 
 `interrupt: {type: reboot}` is required as of 0.6.0, and stays required even with
@@ -276,6 +290,16 @@ host-level steps do need a reboot:
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has
   an effect from the next boot.
+- **Spectrum-X congestion control.** The `configure-spcx-cc` step installs a
+  `doca-spcx-cc@.service` template plus a udev rule, running one `doca_spcx_cc` process
+  per RDMA bond (`mlx5_bond_*`). It is enabled by default; set `spcx_cc: "off"` in the
+  configMap to disable it. Binding the units to devices through udev is what makes the
+  state survive both a reboot and an mlx5 driver reload; started by hand with
+  `systemd-run`, the units are transient and vanish on reboot.
+  The step requires `USER_PROGRAMMABLE_CC` to be enabled in the NIC firmware, since a
+  programmable congestion control algorithm cannot take effect without it, and fails
+  with the `mlxconfig` command to fix it otherwise. Setting firmware stays manual.
+  A node with `spcx_cc: "off"` is never checked.
 
 Both steps are no-ops for every other `service`/`accelerator` pair, so existing `eks`,
 `aks`, and `bcm` deployments are unaffected and still need no `interrupt`.
@@ -287,6 +311,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 | `accelerator` | Yes | — | GPU/accelerator type (e.g., `h100`, `gb200`, `generic`). When set to `generic`, intent and service are ignored |
 | `intent` | No | `performance` | Workload intent (e.g., `inference`, `performance`, `multiNodeTraining`). Ignored when `accelerator=generic` |
 | `service` | No | — | Service name (e.g., `eks`). If specified, service profile wraps the workload profile. Ignored when `accelerator=generic` |
+| `spcx_cc` | No | `on` | DOCA Spectrum-X congestion control. Set to `off` (or `false`, `0`, `no`) to disable it and tear down any units this package installed. Only relevant to a `service`/`accelerator` pair that ships the assets (today `oci` + `gb300`). A node with `spcx_cc: off` does not need DOCA installed. Changing this key re-runs the step, so it can be toggled without a package version bump. |
 
 > **gb300 / oci:** `gb300` ships a `performance` profile only. The base
 > `nvidia-gb300-performance` profile keeps the reboot-requiring `[bootloader]` tuning
@@ -295,7 +320,8 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 > `oci` service also sets the RDMA IPv6 defaults that OCI's IPv6/SLAAC RoCE fabric
 > needs, and installs the bundled NCCL topology file (see `TOPO_PATH` below).
 > As of 0.6.0 the pair also runs the PCIe ACS correction and installs the RDMA VF boot
-> gate, both of which require `interrupt: {type: reboot}` on the custom resource.
+> gate, both of which require `interrupt: {type: reboot}` on the custom resource. As of
+> 0.7.0 it also runs DOCA Spectrum-X congestion control, controlled by `spcx_cc`.
 
 ## Available Profiles
 
@@ -323,7 +349,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 | `eks` | eks-specific settings (MAC address policy for CNI) |
 | `aks` | aks-specific settings (MAC address policy, grub.d bootloader workaround for Ubuntu) |
 | `bcm` | bcm-specific settings (bootloader-free vr200 chain, applies without a reboot) |
-| `oci` | oci-specific settings (RDMA IPv6 defaults, NCCL topology file, PCIe ACS correction and RDMA VF boot gate on gb300; requires `interrupt: {type: reboot}`) |
+| `oci` | oci-specific settings (RDMA IPv6 defaults, NCCL topology file, PCIe ACS correction, RDMA VF boot gate, and Spectrum-X congestion control on gb300; requires `interrupt: {type: reboot}`) |
 
 ### Environment Variables
 
@@ -386,7 +412,7 @@ See the [tuned package README](../tuned/README.md) for complete documentation on
 
 ## Version
 
-- **Package Version**: 0.6.0
+- **Package Version**: 0.7.0
 - **Base Package**: tuned (latest via preprocess.sh)
 - **Schema Version**: v1
 

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,88 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.7.0
+
+Adds DOCA Spectrum-X congestion control for GB300 nodes on OCI.
+
+**Upgrade note: congestion control is enabled by default.** An existing `service: oci`,
+`accelerator: gb300` deployment that moves to 0.7.0 starts running `doca_spcx_cc` with
+no custom resource change, because an absent `spcx_cc` key means on. Set
+`spcx_cc: "off"` in the package configMap before upgrading if that is not wanted.
+Nothing changes for any other `service`/`accelerator` pair: the step resolves bundled
+assets by service and accelerator and is a no-op when a pair ships none.
+
+- **New `config` step `configure-spcx-cc`.** Installs a `doca-spcx-cc@.service` template
+  and a udev rule, then runs one `doca_spcx_cc` process per RDMA bond (`mlx5_bond_*`).
+  These are the host PF bonds, not the VFs that workload pods receive.
+
+  Binding the units to devices through udev is the point. Established by hand with
+  `systemd-run`, the units are transient: they do not
+  survive a reboot, so a rebooted node silently drops out of congestion control. The
+  udev rule also re-instantiates a unit if an mlx5 driver reload removes and recreates
+  the device, which a one-shot enumeration at boot would not.
+
+- **Toggle with the `spcx_cc` configMap key**, not an env var. The operator diffs
+  configMap keys and records them in `status.ConfigUpdates`, so flipping this key
+  re-runs the step and can drive a `configInterrupts` entry; env changes do not. Setting
+  it to a falsey value (`off`, `false`, `0`, `no`) tears down any units this package
+  installed, rather than merely skipping, so the toggle works in both directions.
+
+- **A node with `spcx_cc: "off"` does not need DOCA installed.** The binary is only
+  looked for on the enable path, so opting out never fails a node that lacks the
+  dependency. With it on, a missing binary fails the package with a message naming the
+  cause and the remedy.
+
+- **Refuses to start alongside another owner.** If `doca_spcx_cc` is already running
+  from something this package did not start, the step fails rather than adding a second
+  process per rail; the tool requires exactly one. The error reports the processes,
+  rails, and owning units it actually found rather than assuming particular unit names.
+  On a rack where PCC was established by hand, either stop those units or let the nodes
+  reboot (which clears transient units) before rolling this out.
+
+- **Device selection is by name and structure, not name alone.** The default glob is
+  `mlx5_bond_*`, which is not incidental: `mlx5_ib` uses that name precisely when
+  hardware LAG is active, so it is the driver declaring which devices are bonds. RDMA
+  device names can still be changed, by rdma-core persistent naming or `rdma dev set
+  name`, so `RAIL_GLOB` in the package env overrides the pattern.
+
+  Whatever the glob matches, devices with a `physfn` are skipped: congestion control
+  belongs on host PFs, and a rename can leave a virtual function matching a pattern
+  meant for PFs. This matters on these nodes, where the host itself presents
+  `mlx5_0..3` as VFs alongside the four bonds.
+
+  If nothing matches, the step fails and lists the RDMA devices it did find, rather than
+  installing a udev rule that never fires.
+
+- **Switching it off cannot fail a node.** The off-state check asserts only this
+  package's own artifacts are gone. Congestion control running from somewhere else is
+  reported for context and left alone, because off means this package takes no part, not
+  that nothing else may run it.
+
+- **New `uninstall` step** removes the template unit and udev rule. Processes started
+  outside this package are deliberately left alone.
+
+- **Firmware is checked but never changed.** `USER_PROGRAMMABLE_CC` must read `True(1)`
+  on every rail, because a user-programmable congestion control program cannot take
+  effect without it. It is treated exactly like the DOCA binary: required when the
+  feature is on, never consulted when it is off. A node whose firmware disallows it
+  fails with the offending rail, its PCI address, and the `mlxconfig` command to fix it.
+
+  Setting it remains manual; this package reads these values and never writes them. The other congestion control knobs
+  (`ROCE_CC_STEERING_EXT`, `ROCE_ADAPTIVE_ROUTING_EN`, `TX_SCHEDULER_LOCALITY_MODE`,
+  `PCC_INT_EN`) are reported in the step output but not enforced: their required values
+  are not established, and `PCC_INT_EN` reads `False(0)` on a node where congestion
+  control works, so treating the observed set as mandatory would fail healthy nodes.
+
+  The daemon invocation is the documented one:
+  `doca_spcx_cc -d <rail> -w -1`, with `Restart=on-failure` and `RestartSec=5s`. What
+  differs is only the supervision: a persistent template unit bound to devices by udev,
+  instead of transient units created by hand.
+
+Note on defaults: congestion control trades fairness for tail latency under heavy
+incast, and the effect is workload dependent. `spcx_cc: "off"` is the supported way to
+run without it on nodes where that trade is not wanted.
+
 ## 0.6.0
 
 Adds two host-level fixes for GB300 nodes on OCI.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,13 +1,27 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.6.0",
-    "expected_config_files": ["accelerator"],
+    "package_version": "0.7.0",
+    "expected_config_files": [
+        "accelerator"
+    ],
     "modes": {
         "uninstall": [
             {
                 "name": "uninstall-rdma-vfs-ready",
                 "path": "uninstall_rdma_vfs_ready.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "uninstall-spcx-cc",
+                "path": "uninstall_spcx_cc.sh",
                 "arguments": [],
                 "returncodes": [
                     0
@@ -44,6 +58,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "uninstall-spcx-cc-check",
+                "path": "uninstall_spcx_cc_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
                 "name": "uninstall-check",
                 "path": "uninstall_tuned_check.sh",
                 "arguments": [],
@@ -55,7 +81,6 @@
                 "idempotence": true,
                 "upgrade_step": false
             }
-
         ],
         "upgrade": [
             {
@@ -70,7 +95,6 @@
                 "idempotence": true,
                 "upgrade_step": false
             }
-
         ],
         "upgrade-check": [
             {
@@ -85,7 +109,6 @@
                 "idempotence": true,
                 "upgrade_step": false
             }
-
         ],
         "apply": [
             {
@@ -100,7 +123,6 @@
                 "idempotence": true,
                 "upgrade_step": false
             }
-
         ],
         "apply-check": [
             {
@@ -115,7 +137,6 @@
                 "idempotence": true,
                 "upgrade_step": false
             }
-
         ],
         "config": [
             {
@@ -157,6 +178,18 @@
             {
                 "name": "configure-pcie-acs",
                 "path": "configure_pcie_acs.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": false,
+                "upgrade_step": false
+            },
+            {
+                "name": "configure-spcx-cc",
+                "path": "configure_spcx_cc.sh",
                 "arguments": [],
                 "returncodes": [
                     0
@@ -219,6 +252,18 @@
             {
                 "name": "configure-pcie-acs-check",
                 "path": "configure_pcie_acs_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "configure-spcx-cc-check",
+                "path": "configure_spcx_cc_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0

--- a/nvidia-tuned/profiles/service/oci/spcx-cc-gb300/99-doca-spcx-cc.rules
+++ b/nvidia-tuned/profiles/service/oci/spcx-cc-gb300/99-doca-spcx-cc.rules
@@ -1,0 +1,13 @@
+# Instantiate the DOCA Spectrum-X congestion control unit when an RDMA bond device
+# appears, and stop it when the device goes away.
+#
+# This is what makes the daemon survive more than a clean boot: the processes are bound
+# to devices rather than to a one-shot enumeration, so an mlx5 driver reload that
+# removes and recreates mlx5_bond_* brings congestion control back with it. A discovery
+# service that ran once at boot would not.
+#
+# Only the bonded PFs are matched. The per-rail VFs that workload pods receive are a
+# different device layer and are not congestion control targets.
+
+ACTION=="add", SUBSYSTEM=="infiniband", KERNEL=="mlx5_bond_*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="doca-spcx-cc@$name.service"
+ACTION=="remove", SUBSYSTEM=="infiniband", KERNEL=="mlx5_bond_*", RUN+="/usr/bin/systemctl --no-block stop doca-spcx-cc@$name.service"

--- a/nvidia-tuned/profiles/service/oci/spcx-cc-gb300/doca-spcx-cc@.service
+++ b/nvidia-tuned/profiles/service/oci/spcx-cc-gb300/doca-spcx-cc@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=DOCA Spectrum-X congestion control on %i
+Documentation=https://github.com/NVIDIA/nodewright-packages/tree/main/nvidia-tuned
+# %i is an RDMA device name such as mlx5_bond_0. The device must exist before the
+# process starts; the udev rule instantiates this unit on device add, which covers
+# both boot and a driver reload that removes and recreates the device.
+ConditionPathExists=/sys/class/infiniband/%i
+ConditionPathExists=/opt/mellanox/doca/tools/doca_spcx_cc
+
+[Service]
+Type=simple
+ExecStart=/opt/mellanox/doca/tools/doca_spcx_cc -d %i -w -1
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/nvidia-tuned/skyhook_dir/configure_spcx_cc.sh
+++ b/nvidia-tuned/skyhook_dir/configure_spcx_cc.sh
@@ -64,7 +64,12 @@ MLXCONFIG_BIN="${MLXCONFIG_BIN:-mlxconfig}"
 # treating the observed set as mandatory would fail healthy nodes.
 REQUIRED_FW_SETTING="USER_PROGRAMMABLE_CC"
 REQUIRED_FW_VALUE="True(1)"
-REPORTED_FW_SETTINGS="ROCE_CC_STEERING_EXT ROCE_ADAPTIVE_ROUTING_EN TX_SCHEDULER_LOCALITY_MODE PCC_INT_EN"
+REPORTED_FW_SETTINGS=(
+    ROCE_CC_STEERING_EXT
+    ROCE_ADAPTIVE_ROUTING_EN
+    TX_SCHEDULER_LOCALITY_MODE
+    PCC_INT_EN
+)
 
 # Resolve the bundled asset directory for the configured service/accelerator, if any.
 resolve_asset_dir() {
@@ -135,6 +140,8 @@ teardown() {
     rm -f "${RULES_DEST}"
     rm -f "${UNIT_DEST}"
     systemctl daemon-reload
+    # A failed instance stays loaded after `disable --now` and would still be listed.
+    systemctl reset-failed 'doca-spcx-cc@*.service' >/dev/null 2>&1 || true
     udevadm control --reload >/dev/null 2>&1 || true
 }
 
@@ -156,11 +163,12 @@ owning_unit() {
 # `systemd-run` loop, a unit under any name, or a bare process with no unit at all, so
 # the report lists what was actually found instead of naming units that may not exist.
 assert_no_foreign_processes() {
-    local pids pid unit rail found=0 report=""
-    pids="$(pgrep -x doca_spcx_cc 2>/dev/null || true)"
-    [[ -n "${pids}" ]] || return 0
+    local pid unit rail found=0 report=""
+    local -a pids
+    mapfile -t pids < <(pgrep -x doca_spcx_cc 2>/dev/null || true)
+    [[ "${#pids[@]}" -gt 0 ]] || return 0
 
-    for pid in ${pids}; do
+    for pid in "${pids[@]}"; do
         unit="$(owning_unit "${pid}")"
         # Instances of this package's own template are not foreign.
         [[ "${unit}" == doca-spcx-cc@* ]] && continue
@@ -247,7 +255,7 @@ EOF
         # are not enforced.
         local extra key
         extra=""
-        for key in ${REPORTED_FW_SETTINGS}; do
+        for key in "${REPORTED_FW_SETTINGS[@]}"; do
             extra+=" ${key}=$(fw_setting "${bdf}" "${key}")"
         done
         echo "Firmware ready on ${rail} (${bdf}): ${REQUIRED_FW_SETTING}=${value}${extra}"

--- a/nvidia-tuned/skyhook_dir/configure_spcx_cc.sh
+++ b/nvidia-tuned/skyhook_dir/configure_spcx_cc.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs DOCA Spectrum-X congestion control, one supervised process per RDMA bond.
+#
+# Why this exists: PCC is normally established by hand with `systemd-run`, which creates
+# transient units that do not survive a reboot. This installs a template unit plus a
+# udev rule instead, so each rail's process is bound to its device: it starts at boot,
+# and comes back if an mlx5 driver reload removes and recreates the device.
+#
+# Targets are the host PF bonds (mlx5_bond_*), not the VFs that workload pods receive.
+#
+# This step self-gates on a bundled asset directory at:
+#   ${SKYHOOK_DIR}/profiles/service/${service}/spcx-cc-${accelerator}/
+# so every service/accelerator combination without it is a no-op. Today only
+# service=oci, accelerator=gb300 ships one.
+#
+# Within that shape, the `spcx_cc` configmap key toggles the feature. It defaults to on.
+# Setting it to a falsey value tears the units down and, importantly, never looks for the
+# DOCA binary, so a node that has opted out does not need DOCA installed at all.
+#
+# `spcx_cc` is a configmap key rather than an env var on purpose: the operator diffs
+# configmap keys and records them in status.ConfigUpdates, so flipping it re-runs this
+# step and can drive a targeted `configInterrupts` entry. Env changes do not.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+UNIT_NAME="doca-spcx-cc@.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+RULES_NAME="99-doca-spcx-cc.rules"
+RULES_DEST="/etc/udev/rules.d/${RULES_NAME}"
+
+# Overridable so tests can point at stubs.
+DOCA_SPCX_CC_BIN="${DOCA_SPCX_CC_BIN:-/opt/mellanox/doca/tools/doca_spcx_cc}"
+IB_CLASS_DIR="${IB_CLASS_DIR:-/sys/class/infiniband}"
+RAIL_GLOB="${RAIL_GLOB:-mlx5_bond_*}"
+MLXCONFIG_BIN="${MLXCONFIG_BIN:-mlxconfig}"
+
+# The NIC firmware setting that has to be on for a user-programmable congestion control
+# program to do anything. doca_spcx_cc is exactly such a program.
+#
+# Only this one is required. The other congestion control knobs (ROCE_CC_STEERING_EXT,
+# ROCE_ADAPTIVE_ROUTING_EN, TX_SCHEDULER_LOCALITY_MODE, PCC_INT_EN) are reported below
+# but not enforced, because their required values are not
+# established: PCC_INT_EN reads False on a node where congestion control works, so
+# treating the observed set as mandatory would fail healthy nodes.
+REQUIRED_FW_SETTING="USER_PROGRAMMABLE_CC"
+REQUIRED_FW_VALUE="True(1)"
+REPORTED_FW_SETTINGS="ROCE_CC_STEERING_EXT ROCE_ADAPTIVE_ROUTING_EN TX_SCHEDULER_LOCALITY_MODE PCC_INT_EN"
+
+# Resolve the bundled asset directory for the configured service/accelerator, if any.
+resolve_asset_dir() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 0
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 0
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 0
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 0
+
+    local candidate="${PROFILES_DIR}/service/${service}/spcx-cc-${accelerator}"
+    [[ -d "${candidate}" ]] || return 0
+    [[ -f "${candidate}/${UNIT_NAME}" ]] || return 0
+    [[ -f "${candidate}/${RULES_NAME}" ]] || return 0
+
+    echo "${candidate}"
+}
+
+# Returns 0 unless the operator switched the feature off. Defaults to on.
+spcx_cc_requested() {
+    local setting
+    [[ -f "${CONFIGMAP_DIR}/spcx_cc" ]] || return 0
+    setting="$(xargs < "${CONFIGMAP_DIR}/spcx_cc" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Echo each RDMA bond device present on this node, one per line.
+#
+# `mlx5_bond_%d` is not incidental naming: mlx5_ib uses it precisely when hardware LAG
+# is active, so the default glob is the driver declaring which devices are bonds. RDMA
+# device names can still be changed, by rdma-core's persistent-naming udev rules or an
+# explicit `rdma dev set <dev> name <new>`, which is what RAIL_GLOB exists for.
+#
+# Devices with a physfn are skipped whatever the glob says. Congestion control belongs
+# on the host PFs, and a rename can leave a VF matching a pattern intended for PFs. On
+# these nodes the host's own mlx5_0..3 are VFs, so a broader glob would otherwise target
+# them.
+discover_rails() {
+    local path name
+    for path in "${IB_CLASS_DIR}/"${RAIL_GLOB}; do
+        [[ -e "${path}" ]] || continue
+        name="$(basename "${path}")"
+        if [[ -e "${path}/device/physfn" ]]; then
+            echo "Skipping ${name}: it is a virtual function, not a host PF" >&2
+            continue
+        fi
+        echo "${name}"
+    done
+}
+
+# Stop and disable every instance of the template, whether or not it is ours, and remove
+# the udev rule. Deliberately does not touch DOCA: teardown must work on a node that
+# never had it installed.
+teardown() {
+    local unit
+    while read -r unit; do
+        [[ -n "${unit}" ]] || continue
+        systemctl disable --now "${unit}" >/dev/null 2>&1 || true
+        echo "Stopped and disabled ${unit}"
+    done < <(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '{print $1}')
+
+    rm -f "${RULES_DEST}"
+    rm -f "${UNIT_DEST}"
+    systemctl daemon-reload
+    udevadm control --reload >/dev/null 2>&1 || true
+}
+
+# Report the systemd unit owning a pid, or an empty string if none does. Reads the
+# cgroup rather than parsing `systemctl status`, so it works for transient units and
+# for processes started outside systemd entirely.
+owning_unit() {
+    local pid="$1" cgroup
+    # Read first, then parse. A `... | head -1` pipeline can return 141 under pipefail
+    # when head exits before the reader finishes, and cgroup v1 emits many lines.
+    cgroup="$(cat "/proc/${pid}/cgroup" 2>/dev/null || true)"
+    awk -F/ '$NF ~ /\.service$/ { print $NF; exit }' <<< "${cgroup}"
+}
+
+# A doca_spcx_cc process this package did not start is a second owner of the same rail.
+# The tool requires exactly one process per rail, so refuse rather than double up.
+#
+# What started them is not assumed. They may be transient units from a hand-run
+# `systemd-run` loop, a unit under any name, or a bare process with no unit at all, so
+# the report lists what was actually found instead of naming units that may not exist.
+assert_no_foreign_processes() {
+    local pids pid unit rail found=0 report=""
+    pids="$(pgrep -x doca_spcx_cc 2>/dev/null || true)"
+    [[ -n "${pids}" ]] || return 0
+
+    for pid in ${pids}; do
+        unit="$(owning_unit "${pid}")"
+        # Instances of this package's own template are not foreign.
+        [[ "${unit}" == doca-spcx-cc@* ]] && continue
+
+        rail="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null | sed -n 's/.*-d[= ]\([^ ]*\).*/\1/p')"
+        report+="    pid ${pid}  rail ${rail:-unknown}  owner ${unit:-<no systemd unit>}"$'\n'
+        found=$((found + 1))
+    done
+
+    [[ "${found}" -gt 0 ]] || return 0
+
+    cat <<EOF
+ERROR: DOCA Spectrum-X congestion control is already running outside this package.
+
+  Found ${found} doca_spcx_cc process(es) this package does not own:
+
+${report}
+  Starting this package's units as well would give those rails two processes, and the
+  tool requires exactly one per rail.
+
+  Remedy: stop whatever owns the processes listed above, then re-run. Where an owner is
+  shown, \`systemctl stop <owner>\` is usually enough; note that units created by
+  \`systemd-run\` are transient and also disappear on reboot. Alternatively set
+  \`spcx_cc: "off"\` in the package configMap to leave them alone and have this package
+  take no part in congestion control.
+EOF
+    exit 1
+}
+
+# Echo the PCI address backing an RDMA device, e.g. 0000:03:00.0.
+rail_bdf() {
+    local rail="$1" target
+    target="$(readlink -f "${IB_CLASS_DIR}/${rail}/device" 2>/dev/null)"
+    [[ -n "${target}" ]] && basename "${target}"
+}
+
+# Read one mlxconfig setting for a device. Echoes the value, or nothing if unavailable.
+fw_setting() {
+    local bdf="$1" key="$2" out
+    # Captured rather than piped: awk exits at the first match, which can leave
+    # mlxconfig writing into a closed pipe and fail the whole pipeline under pipefail.
+    out="$("${MLXCONFIG_BIN}" -d "${bdf}" q 2>/dev/null || true)"
+    awk -v k="${key}" '$1 == k { print $2; exit }' <<< "${out}"
+}
+
+# Congestion control needs the NIC firmware to allow a user-programmable algorithm. That
+# is a prerequisite of the feature, so it is treated like the DOCA binary: required when
+# the feature is on, never consulted when it is off.
+assert_firmware_ready() {
+    local rails="$1" rail bdf value failed=0
+
+    if ! command -v "${MLXCONFIG_BIN}" >/dev/null 2>&1; then
+        cat <<EOF
+ERROR: Spectrum-X congestion control was requested but its prerequisites cannot be checked.
+
+  ${MLXCONFIG_BIN} is not available on this node. It ships with the NVIDIA firmware
+  tools (mft) and is needed to confirm the NIC allows user-programmable congestion
+  control.
+
+  Remedy: install the firmware tools, or set \`spcx_cc: "off"\` in the package configMap
+  to run this node without congestion control. A node that is switched off does not need
+  them.
+EOF
+        exit 1
+    fi
+
+    while read -r rail; do
+        [[ -n "${rail}" ]] || continue
+        bdf="$(rail_bdf "${rail}")"
+        if [[ -z "${bdf}" ]]; then
+            echo "ERROR: could not resolve a PCI address for ${rail}"
+            failed=1
+            continue
+        fi
+
+        value="$(fw_setting "${bdf}" "${REQUIRED_FW_SETTING}")"
+        if [[ "${value}" != "${REQUIRED_FW_VALUE}" ]]; then
+            echo "ERROR: ${rail} (${bdf}): ${REQUIRED_FW_SETTING} is ${value:-unreadable}, need ${REQUIRED_FW_VALUE}"
+            failed=1
+            continue
+        fi
+
+        # Reported for diagnostics only; see REPORTED_FW_SETTINGS above for why these
+        # are not enforced.
+        local extra key
+        extra=""
+        for key in ${REPORTED_FW_SETTINGS}; do
+            extra+=" ${key}=$(fw_setting "${bdf}" "${key}")"
+        done
+        echo "Firmware ready on ${rail} (${bdf}): ${REQUIRED_FW_SETTING}=${value}${extra}"
+    done <<< "${rails}"
+
+    if [[ "${failed}" -ne 0 ]]; then
+        cat <<EOF
+
+  Congestion control cannot take effect while the NIC firmware disallows a
+  user-programmable algorithm. The daemon would run without doing anything useful.
+
+  ${REQUIRED_FW_SETTING} is a persistent firmware setting, not something this package
+  manages. Set it with
+  \`mlxconfig -d <pci-address> set ${REQUIRED_FW_SETTING}=1\` and reboot, or set
+  \`spcx_cc: "off"\` in the package configMap to run this node without congestion
+  control.
+EOF
+        exit 1
+    fi
+}
+
+main() {
+    local src
+    src="$(resolve_asset_dir)"
+
+    if [[ -z "${src}" ]]; then
+        echo "No bundled Spectrum-X congestion control assets for this service/accelerator; nothing to do"
+        return 0
+    fi
+
+    if ! spcx_cc_requested; then
+        # No DOCA lookup on this path: opting out must never require the dependency.
+        echo "Spectrum-X congestion control switched off via the spcx_cc configmap key; tearing down"
+        teardown
+        return 0
+    fi
+
+    if [[ ! -x "${DOCA_SPCX_CC_BIN}" ]]; then
+        cat <<EOF
+ERROR: Spectrum-X congestion control was requested but cannot be started.
+
+  ${DOCA_SPCX_CC_BIN} is not present or not executable on this node. It ships with the
+  DOCA install in the node image; a node without it cannot run congestion control.
+
+  Impact: this node would run without congestion control while the rest of the rack has
+  it. Mixed PCC state across a rack produces uneven tail latency under incast and makes
+  results difficult to interpret.
+
+  Remedy: install DOCA on this node, or set \`spcx_cc: "off"\` in the package configMap
+  to run this node without congestion control. A node that is switched off does not need
+  DOCA installed.
+EOF
+        exit 1
+    fi
+
+    assert_no_foreign_processes
+
+    # Every prerequisite is settled before anything is written to the host. Installing
+    # the udev rule first would leave a node that fails a later check with a rule that
+    # can still instantiate units on the next device event.
+    local rails rail started=0
+    rails="$(discover_rails)"
+    if [[ -z "${rails}" ]]; then
+        # Bonded PFs are created by the mlx5 driver at load, so on a node that has any
+        # they exist well before this runs. Finding none means the device naming is not
+        # what this package expects, most likely because LAG is off. Fail loudly and
+        # show what is actually there rather than installing a rule that never fires.
+        echo "ERROR: no ${RAIL_GLOB} devices found under ${IB_CLASS_DIR}."
+        echo "       Congestion control targets the bonded PFs. RDMA devices present:"
+        local dev
+        for dev in "${IB_CLASS_DIR}"/*; do
+            [[ -e "${dev}" ]] || continue
+            echo "         $(basename "${dev}")"
+        done
+        echo "       If this node names its bonds differently, override RAIL_GLOB in the"
+        echo "       package env. If it has no bonded PFs, set \`spcx_cc: \"off\"\`."
+        exit 1
+    fi
+
+    assert_firmware_ready "${rails}"
+
+    install -D -m 0644 "${src}/${UNIT_NAME}" "${UNIT_DEST}"
+    echo "Installed ${src}/${UNIT_NAME} -> ${UNIT_DEST}"
+
+    install -D -m 0644 "${src}/${RULES_NAME}" "${RULES_DEST}"
+    echo "Installed ${src}/${RULES_NAME} -> ${RULES_DEST}"
+
+    systemctl daemon-reload
+    udevadm control --reload >/dev/null 2>&1 || true
+
+    # Enable so the units come back on reboot even before udev fires, and start now so
+    # the change takes effect without waiting for one. Both are idempotent: systemd
+    # allows only one instance per device name, which is what the tool requires.
+    while read -r rail; do
+        [[ -n "${rail}" ]] || continue
+        systemctl enable --now "doca-spcx-cc@${rail}.service"
+        echo "Started doca-spcx-cc@${rail}.service"
+        started=$((started + 1))
+    done <<< "${rails}"
+
+    echo "Spectrum-X congestion control running on ${started} rail(s)"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_spcx_cc_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_spcx_cc_check.sh
@@ -75,11 +75,16 @@ spcx_cc_requested() {
     esac
 }
 
+# Mirrors discover_rails() in configure_spcx_cc.sh, including the physfn exclusion.
+# Without it a glob that matches a virtual function would make this demand a unit the
+# configure step deliberately never started.
 discover_rails() {
-    local path
+    local path name
     for path in "${IB_CLASS_DIR}/"${RAIL_GLOB}; do
         [[ -e "${path}" ]] || continue
-        basename "${path}"
+        name="$(basename "${path}")"
+        [[ -e "${path}/device/physfn" ]] && continue
+        echo "${name}"
     done
 }
 
@@ -93,11 +98,12 @@ owning_unit() {
 # Returns non-zero when a doca_spcx_cc process is owned by anything other than this
 # package's template. Mirrors the configure-time guard so drift after config is caught.
 assert_no_foreign_processes() {
-    local pids pid unit rail found=0
-    pids="$(pgrep -x doca_spcx_cc 2>/dev/null || true)"
-    [[ -n "${pids}" ]] || return 0
+    local pid unit rail found=0
+    local -a pids
+    mapfile -t pids < <(pgrep -x doca_spcx_cc 2>/dev/null || true)
+    [[ "${#pids[@]}" -gt 0 ]] || return 0
 
-    for pid in ${pids}; do
+    for pid in "${pids[@]}"; do
         unit="$(owning_unit "${pid}")"
         [[ "${unit}" == doca-spcx-cc@* ]] && continue
         rail="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null | sed -n 's/.*-d[= ]\([^ ]*\).*/\1/p')"

--- a/nvidia-tuned/skyhook_dir/configure_spcx_cc_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_spcx_cc_check.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies configure_spcx_cc.sh left congestion control in the requested state.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly.
+#
+# When the feature is switched off, this verifies nothing is running and never looks for
+# the DOCA binary: a node that opted out must not need the dependency installed.
+#
+# When it is on, an active unit is not sufficient. The daemon reports readiness in its
+# own log, and initialization has been observed to take longer than eight seconds, so
+# this waits for `PCC host status Active` per rail rather than trusting unit state or a
+# fixed sleep.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+UNIT_NAME="doca-spcx-cc@.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+RULES_NAME="99-doca-spcx-cc.rules"
+RULES_DEST="/etc/udev/rules.d/${RULES_NAME}"
+
+IB_CLASS_DIR="${IB_CLASS_DIR:-/sys/class/infiniband}"
+RAIL_GLOB="${RAIL_GLOB:-mlx5_bond_*}"
+READY_PATTERN="${READY_PATTERN:-PCC host status Active}"
+READY_TIMEOUT_SECS="${READY_TIMEOUT_SECS:-60}"
+READY_POLL_SECS="${READY_POLL_SECS:-2}"
+
+# Mirrors resolve_asset_dir() in configure_spcx_cc.sh.
+resolve_asset_dir() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 0
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 0
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 0
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 0
+
+    local candidate="${PROFILES_DIR}/service/${service}/spcx-cc-${accelerator}"
+    [[ -d "${candidate}" ]] || return 0
+    [[ -f "${candidate}/${UNIT_NAME}" ]] || return 0
+
+    echo "${candidate}"
+}
+
+# Mirrors spcx_cc_requested() in configure_spcx_cc.sh.
+spcx_cc_requested() {
+    local setting
+    [[ -f "${CONFIGMAP_DIR}/spcx_cc" ]] || return 0
+    setting="$(xargs < "${CONFIGMAP_DIR}/spcx_cc" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+discover_rails() {
+    local path
+    for path in "${IB_CLASS_DIR}/"${RAIL_GLOB}; do
+        [[ -e "${path}" ]] || continue
+        basename "${path}"
+    done
+}
+
+# Mirrors owning_unit() in configure_spcx_cc.sh.
+owning_unit() {
+    local pid="$1" cgroup
+    cgroup="$(cat "/proc/${pid}/cgroup" 2>/dev/null || true)"
+    awk -F/ '$NF ~ /\.service$/ { print $NF; exit }' <<< "${cgroup}"
+}
+
+# Returns non-zero when a doca_spcx_cc process is owned by anything other than this
+# package's template. Mirrors the configure-time guard so drift after config is caught.
+assert_no_foreign_processes() {
+    local pids pid unit rail found=0
+    pids="$(pgrep -x doca_spcx_cc 2>/dev/null || true)"
+    [[ -n "${pids}" ]] || return 0
+
+    for pid in ${pids}; do
+        unit="$(owning_unit "${pid}")"
+        [[ "${unit}" == doca-spcx-cc@* ]] && continue
+        rail="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null | sed -n 's/.*-d[= ]\([^ ]*\).*/\1/p')"
+        if [[ "${found}" -eq 0 ]]; then
+            echo "ERROR: doca_spcx_cc process(es) running outside this package:"
+        fi
+        echo "    pid ${pid}  rail ${rail:-unknown}  owner ${unit:-<no systemd unit>}"
+        found=$((found + 1))
+    done
+
+    [[ "${found}" -eq 0 ]]
+}
+
+# Wait for the daemon to report readiness in its journal. Returns non-zero on timeout.
+wait_for_ready() {
+    local unit="$1" elapsed=0 log
+    while [[ "${elapsed}" -lt "${READY_TIMEOUT_SECS}" ]]; do
+        # Captured rather than piped: `grep -q` exits at the first match, so under
+        # pipefail the pipeline can return 141 and be misread as "not ready".
+        log="$(journalctl -u "${unit}" --no-pager 2>/dev/null || true)"
+        if grep -qF "${READY_PATTERN}" <<< "${log}"; then
+            return 0
+        fi
+        if ! systemctl is-active --quiet "${unit}"; then
+            return 1
+        fi
+        sleep "${READY_POLL_SECS}"
+        elapsed=$((elapsed + READY_POLL_SECS))
+    done
+    return 1
+}
+
+verify_off() {
+    # Only this package's own artifacts are asserted. Switching the feature off means
+    # this package takes no part in congestion control, not that nothing else may run
+    # it: processes started elsewhere are not ours to stop, so their presence is not an
+    # "off" failure. The uninstall check reasons about them the same way.
+    if [[ -e "${RULES_DEST}" ]]; then
+        echo "ERROR: spcx_cc is off but the udev rule is still present at ${RULES_DEST}"
+        exit 1
+    fi
+
+    if [[ -e "${UNIT_DEST}" ]]; then
+        echo "ERROR: spcx_cc is off but the unit template is still present at ${UNIT_DEST}"
+        exit 1
+    fi
+
+    local remaining
+    remaining="$(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '{print $1}')"
+    if [[ -n "${remaining}" ]]; then
+        echo "ERROR: spcx_cc is off but this package's unit(s) are still known to systemd:"
+        local unit
+        while read -r unit; do
+            [[ -n "${unit}" ]] || continue
+            echo "  ${unit}"
+        done <<< "${remaining}"
+        exit 1
+    fi
+
+    # Report anything else running congestion control, without failing on it. Useful
+    # context when a node is deliberately excluded while the rest of a rack is not.
+    local foreign
+    foreign="$(pgrep -xc doca_spcx_cc 2>/dev/null || true)"
+    if [[ "${foreign:-0}" -ne 0 ]]; then
+        echo "Note: ${foreign} doca_spcx_cc process(es) are running from outside this package."
+        echo "      They are left alone because spcx_cc is off."
+    fi
+
+    echo "Verified Spectrum-X congestion control is off"
+}
+
+verify_on() {
+    local src="$1"
+
+    if [[ ! -f "${UNIT_DEST}" ]]; then
+        echo "ERROR: unit template missing at ${UNIT_DEST}"
+        exit 1
+    fi
+
+    if ! cmp -s "${src}/${UNIT_NAME}" "${UNIT_DEST}"; then
+        echo "ERROR: ${UNIT_DEST} does not match bundled ${src}/${UNIT_NAME}"
+        exit 1
+    fi
+
+    if [[ ! -f "${RULES_DEST}" ]]; then
+        echo "ERROR: udev rule missing at ${RULES_DEST}"
+        exit 1
+    fi
+
+    local rails rail unit failed=0 checked=0
+    rails="$(discover_rails)"
+
+    if [[ -z "${rails}" ]]; then
+        echo "ERROR: no ${RAIL_GLOB} devices found under ${IB_CLASS_DIR}; cannot run congestion control"
+        exit 1
+    fi
+
+    while read -r rail; do
+        [[ -n "${rail}" ]] || continue
+        unit="doca-spcx-cc@${rail}.service"
+        checked=$((checked + 1))
+
+        if ! systemctl is-active --quiet "${unit}"; then
+            echo "ERROR: ${unit} is not active"
+            systemctl status --no-pager "${unit}" 2>&1 | head -20 || true
+            failed=1
+            continue
+        fi
+
+        if ! wait_for_ready "${unit}"; then
+            echo "ERROR: ${unit} did not report '${READY_PATTERN}' within ${READY_TIMEOUT_SECS}s"
+            journalctl -u "${unit}" --no-pager 2>/dev/null | tail -20 || true
+            failed=1
+            continue
+        fi
+
+        echo "Verified ${unit} is active and reporting ready"
+    done <<< "${rails}"
+
+    # Whether this package's rails are running is systemd's word, asserted above. What
+    # that cannot tell us is whether something else is also running PCC, which would
+    # give a rail two processes. Check for owners other than this package's template
+    # rather than comparing a raw process count, so the assertion stays meaningful
+    # regardless of how many rails the node has.
+    if ! assert_no_foreign_processes; then
+        failed=1
+    fi
+
+    [[ "${failed}" -eq 0 ]] || exit 1
+    echo "Spectrum-X congestion control verified on ${checked} rail(s)"
+}
+
+main() {
+    local src
+    src="$(resolve_asset_dir)"
+
+    if [[ -z "${src}" ]]; then
+        echo "No bundled Spectrum-X congestion control assets for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if ! spcx_cc_requested; then
+        verify_off
+        return 0
+    fi
+
+    verify_on "${src}"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_spcx_cc.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_spcx_cc.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Removes the DOCA Spectrum-X congestion control units and udev rule.
+#
+# Runs unconditionally rather than self-gating on the service/accelerator assets:
+# uninstall must also clean up after a custom resource whose configmaps have since
+# changed, so it keys on what is on the host, not on what the package currently bundles.
+# Removing units that were never installed is a no-op.
+#
+# Never looks for the DOCA binary. Teardown has to work on a node where DOCA was removed,
+# or was never installed because the feature was switched off.
+#
+# Only units matching this package's template are touched. Processes started by hand
+# through `systemd-run` (transient doca-spcx-cc-rail* units) belong to whoever created
+# them and are deliberately left alone.
+
+set -euo pipefail
+
+UNIT_NAME="doca-spcx-cc@.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+RULES_NAME="99-doca-spcx-cc.rules"
+RULES_DEST="/etc/udev/rules.d/${RULES_NAME}"
+
+main() {
+    # Remove the udev rule first so a device event cannot re-instantiate a unit while
+    # the teardown is in progress.
+    if [[ -e "${RULES_DEST}" ]]; then
+        rm -f "${RULES_DEST}"
+        udevadm control --reload >/dev/null 2>&1 || true
+        echo "Removed ${RULES_DEST}"
+    fi
+
+    local unit stopped=0
+    while read -r unit; do
+        [[ -n "${unit}" ]] || continue
+        systemctl disable --now "${unit}" >/dev/null 2>&1 || true
+        echo "Stopped and disabled ${unit}"
+        stopped=$((stopped + 1))
+    done < <(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '{print $1}')
+
+    rm -f "${UNIT_DEST}"
+    systemctl daemon-reload
+
+    if [[ "${stopped}" -eq 0 ]]; then
+        echo "No doca-spcx-cc@ units were present; nothing to stop"
+    fi
+    echo "Spectrum-X congestion control removed"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_spcx_cc.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_spcx_cc.sh
@@ -56,6 +56,9 @@ main() {
 
     rm -f "${UNIT_DEST}"
     systemctl daemon-reload
+    # A failed instance stays loaded after `disable --now`, and the uninstall check
+    # would read that as incomplete cleanup.
+    systemctl reset-failed 'doca-spcx-cc@*.service' >/dev/null 2>&1 || true
 
     if [[ "${stopped}" -eq 0 ]]; then
         echo "No doca-spcx-cc@ units were present; nothing to stop"

--- a/nvidia-tuned/skyhook_dir/uninstall_spcx_cc_check.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_spcx_cc_check.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies uninstall_spcx_cc.sh removed this package's congestion control units.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly.
+#
+# Deliberately does not assert that no doca_spcx_cc process is running: hand-started
+# transient units are not this package's to remove, so their presence is not an
+# uninstall failure.
+
+set -uo pipefail
+
+UNIT_NAME="doca-spcx-cc@.service"
+UNIT_DEST="/etc/systemd/system/${UNIT_NAME}"
+RULES_NAME="99-doca-spcx-cc.rules"
+RULES_DEST="/etc/udev/rules.d/${RULES_NAME}"
+
+main() {
+    if [[ -e "${UNIT_DEST}" ]]; then
+        echo "ERROR: ${UNIT_DEST} still present"
+        exit 1
+    fi
+
+    if [[ -e "${RULES_DEST}" ]]; then
+        echo "ERROR: ${RULES_DEST} still present"
+        exit 1
+    fi
+
+    local remaining
+    remaining="$(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '{print $1}')"
+    if [[ -n "${remaining}" ]]; then
+        echo "ERROR: doca-spcx-cc@ unit(s) still known to systemd:"
+        local unit
+        while read -r unit; do
+            [[ -n "${unit}" ]] || continue
+            echo "  ${unit}"
+        done <<< "${remaining}"
+        exit 1
+    fi
+
+    echo "Verified Spectrum-X congestion control units are removed"
+}
+
+main "$@"

--- a/tests/integration/nvidia_tuned/fakes/doca_spcx_cc
+++ b/tests/integration/nvidia_tuned/fakes/doca_spcx_cc
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for the DOCA Spectrum-X congestion control daemon. Only its presence and
+# argument shape matter to the lifecycle scripts; nothing here talks to a device.
+
+set -euo pipefail
+
+device=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -d | --device) device="${2:-}"; shift 2 ;;
+        --device=*) device="${1#*=}"; shift ;;
+        -w) shift; shift || true ;;
+        *)
+            echo "fake doca_spcx_cc: unsupported argument '$1'" >&2
+            exit 64
+            ;;
+    esac
+done
+
+if [[ -z "${device}" ]]; then
+    echo "fake doca_spcx_cc: no device given" >&2
+    exit 64
+fi
+
+echo "PCC host status Active on ${device}"
+# The real daemon runs until stopped when given -w -1.
+while true; do sleep 3600; done

--- a/tests/integration/nvidia_tuned/fakes/doca_spcx_cc
+++ b/tests/integration/nvidia_tuned/fakes/doca_spcx_cc
@@ -26,7 +26,11 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         -d | --device) device="${2:-}"; shift 2 ;;
         --device=*) device="${1#*=}"; shift ;;
-        -w) shift; shift || true ;;
+        -w)
+            # The service contract is `-w -1`; anything else means a wrong ExecStart.
+            [[ "${2:-}" == "-1" ]] || { echo "fake doca_spcx_cc: expected -w -1" >&2; exit 64; }
+            shift 2
+            ;;
         *)
             echo "fake doca_spcx_cc: unsupported argument '$1'" >&2
             exit 64

--- a/tests/integration/nvidia_tuned/fakes/journalctl
+++ b/tests/integration/nvidia_tuned/fakes/journalctl
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for journalctl, scoped to what the congestion control check reads.
+#
+# Emits the daemon's readiness line for a unit only once that unit is marked active by
+# the fake systemctl. Set FAKE_JOURNAL_NEVER_READY=1 to model a daemon that starts but
+# never reports ready, which is the case the check must not silently pass.
+
+set -euo pipefail
+
+STATE_DIR="${FAKE_SYSTEMCTL_STATE:-/tmp/fake-systemctl}"
+
+unit=""
+prev=""
+for arg in "$@"; do
+    [[ "${prev}" == "-u" ]] && unit="${arg}"
+    prev="${arg}"
+done
+
+if [[ -z "${unit}" ]]; then
+    # Fail loudly rather than returning empty output for an unmodelled invocation.
+    echo "fake journalctl: expected -u <unit>" >&2
+    exit 64
+fi
+[[ -e "${STATE_DIR}/active.${unit}" ]] || exit 0
+[[ "${FAKE_JOURNAL_NEVER_READY:-0}" == "1" ]] && exit 0
+
+device="${unit#doca-spcx-cc@}"
+device="${device%.service}"
+echo "PCC host status Active on ${device}"

--- a/tests/integration/nvidia_tuned/fakes/mlxconfig
+++ b/tests/integration/nvidia_tuned/fakes/mlxconfig
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for mlxconfig, reproducing the output shape and the values observed on a
+# working OCI GB300 node. Note PCC_INT_EN reads False there, which is why it is not
+# treated as a prerequisite.
+#
+# FAKE_USER_PROGRAMMABLE_CC overrides the reported value, so the disabled-firmware path
+# can be exercised. FAKE_MLXCONFIG_DEVICE_FAIL names a PCI address to report as disabled.
+
+set -euo pipefail
+
+device=""
+prev=""
+for arg in "$@"; do
+    [[ "${prev}" == "-d" ]] && device="${arg}"
+    prev="${arg}"
+done
+
+subcommand=""
+for arg in "$@"; do
+    case "${arg}" in
+        -d | --device) continue ;;
+        -*) continue ;;
+    esac
+    [[ "${arg}" == "${device}" ]] && continue
+    subcommand="${arg}"
+    break
+done
+
+case "${subcommand}" in
+    q | query) ;;
+    *)
+        # Fail loudly rather than returning query output for an unmodelled subcommand.
+        echo "fake mlxconfig: unsupported subcommand '${subcommand:-<none>}'" >&2
+        exit 64
+        ;;
+esac
+
+upcc="${FAKE_USER_PROGRAMMABLE_CC:-True(1)}"
+if [[ -n "${FAKE_MLXCONFIG_DEVICE_FAIL:-}" && "${device}" == "${FAKE_MLXCONFIG_DEVICE_FAIL}" ]]; then
+    upcc="False(0)"
+fi
+
+cat <<EOF
+
+Device #1:
+----------
+
+Device type:    ConnectX8
+Name:           fake
+Device:         ${device}
+
+Configurations:                              Next Boot
+        ROCE_CC_STEERING_EXT                        ENABLED(2)
+        PCC_INT_EN                                  False(0)
+        TX_SCHEDULER_LOCALITY_MODE                  ACCUMULATIVE(2)
+        USER_PROGRAMMABLE_CC                        ${upcc}
+        ROCE_ADAPTIVE_ROUTING_EN                    True(1)
+
+Apply new Configuration? (y/n) [n] : y
+EOF

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -68,6 +68,15 @@ case "${verb}" in
     stop)
         rm -f "${STATE_DIR}/active.${unit}"
         ;;
+    reset-failed)
+        # Clears failed state. Accepts a glob, matching how the teardown calls it.
+        for marker in "${STATE_DIR}"/failed.*; do
+            [[ -e "${marker}" ]] || continue
+            name="${marker##*/}"; name="${name#failed.}"
+            # shellcheck disable=SC2053
+            [[ -z "${unit}" || "${name}" == ${unit} ]] && rm -f "${marker}"
+        done
+        ;;
     is-enabled)
         if [[ -f "${STATE_DIR}/enabled.${unit}" ]]; then
             echo "enabled"

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -87,6 +87,25 @@ case "${verb}" in
     status)
         echo "fake status for ${unit}"
         ;;
+    list-units)
+        # `unit` holds the glob the caller passed, e.g. 'doca-spcx-cc@*.service'.
+        # Emit one unit name per line; callers take field 1.
+        seen=""
+        for marker in "${STATE_DIR}"/enabled.* "${STATE_DIR}"/active.*; do
+            [[ -e "${marker}" ]] || continue
+            name="${marker##*/}"
+            name="${name#enabled.}"
+            name="${name#active.}"
+            case " ${seen} " in *" ${name} "*) continue ;; esac
+            seen="${seen} ${name}"
+            # Glob matching on the right-hand side is the point: callers pass a
+            # pattern such as 'doca-spcx-cc@*.service'.
+            # shellcheck disable=SC2053
+            if [[ -z "${unit}" || "${name}" == ${unit} ]]; then
+                echo "${name} loaded active running fake unit"
+            fi
+        done
+        ;;
     *)
         # Fail loudly rather than silently succeeding. A double that returns 0 for an
         # unmodelled verb would let a script appear to work while doing nothing.

--- a/tests/integration/nvidia_tuned/fakes/udevadm
+++ b/tests/integration/nvidia_tuned/fakes/udevadm
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for udevadm. Records invocations so tests can assert the rule reload
+# happened, and fails on unmodelled subcommands rather than silently succeeding.
+
+set -euo pipefail
+
+STATE_DIR="${FAKE_UDEV_STATE:-/tmp/fake-udev}"
+mkdir -p "${STATE_DIR}"
+echo "$*" >> "${STATE_DIR}/calls"
+
+case "${1:-}" in
+    control | trigger | settle) exit 0 ;;
+    *)
+        echo "fake udevadm: unsupported subcommand '${1:-}'" >&2
+        exit 64
+        ;;
+esac

--- a/tests/integration/nvidia_tuned/test_spcx_cc.py
+++ b/tests/integration/nvidia_tuned/test_spcx_cc.py
@@ -369,6 +369,11 @@ def test_spcx_cc_never_targets_a_virtual_function(node):
     assert exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@rdma_rail0.service")
     assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@rdma_rail1.service")
 
+    # The check must apply the same exclusion. Without it, it would demand an active
+    # unit for the VF that configure deliberately never started.
+    rc = step(node, "configure_spcx_cc_check.sh", {"RAIL_GLOB": "rdma_rail*"})
+    assert rc == 0, output(node)
+
 
 def test_spcx_cc_ignores_host_vfs_with_a_broad_glob(node):
     """Even mlx5_* must not start congestion control on the host's own VFs."""

--- a/tests/integration/nvidia_tuned/test_spcx_cc.py
+++ b/tests/integration/nvidia_tuned/test_spcx_cc.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the DOCA Spectrum-X congestion control steps.
+
+The feature is gated twice: on bundled assets for the service/accelerator pair, and on
+the `spcx_cc` configmap key, which defaults to on. The most important behaviour is that
+switching it off never requires the DOCA binary, so a node that opted out does not need
+the dependency installed.
+
+Real systemctl, journalctl, udevadm, and the DOCA daemon are replaced by doubles in
+fakes/. `pgrep` is the container's own, so the foreign-process guard is exercised
+against a genuinely running process rather than a stub.
+
+Assertions resolve to exit codes; see test_host_setup.py for why.
+"""
+
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.docker_test import DockerTestRunner
+
+BASE_IMAGE = "ubuntu:24.04"
+
+FAKES_DIR = Path(__file__).resolve().parent / "fakes"
+FAKE_BIN = "/fakes"
+OUTPUT_FILE = "/tmp/step-output"
+
+UNIT_DEST = "/etc/systemd/system/doca-spcx-cc@.service"
+RULES_DEST = "/etc/udev/rules.d/99-doca-spcx-cc.rules"
+BUNDLED_DIR = "/skyhook-package/profiles/service/oci/spcx-cc-gb300"
+DOCA_BIN = f"{FAKE_BIN}/doca_spcx_cc"
+IB_DIR = "/tmp/infiniband"
+
+STEP_ENV = {
+    "SKYHOOK_DIR": "/skyhook-package",
+    "STEP_ROOT": "/skyhook-package/skyhook_dir",
+    "PATH": f"{FAKE_BIN}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "FAKE_SYSTEMCTL_STATE": "/tmp/fake-systemctl",
+    "FAKE_UDEV_STATE": "/tmp/fake-udev",
+    "DOCA_SPCX_CC_BIN": DOCA_BIN,
+    "IB_CLASS_DIR": IB_DIR,
+    "READY_TIMEOUT_SECS": "6",
+    "READY_POLL_SECS": "1",
+}
+
+OCI_GB300 = {"accelerator": "gb300", "service": "oci"}
+OTHER_SHAPES = [
+    {"accelerator": "h100", "service": "eks"},
+    {"accelerator": "gb200", "service": "oci"},
+    {"accelerator": "gb300"},
+]
+OTHER_SHAPE_IDS = ["eks-h100", "oci-gb200", "gb300-no-service"]
+
+
+@pytest.fixture
+def node():
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=BASE_IMAGE)
+    temp_dir = Path(tempfile.mkdtemp(prefix="skyhook-test-"))
+    runner.temp_dir = str(temp_dir)
+
+    package_dir = temp_dir / "skyhook-package"
+    shutil.copytree(runner._package_path, package_dir, dirs_exist_ok=True)
+    for sh_file in package_dir.rglob("*.sh"):
+        sh_file.chmod(0o755)
+    (package_dir / "configmaps").mkdir(parents=True, exist_ok=True)
+    (package_dir / "node-metadata").mkdir(parents=True, exist_ok=True)
+
+    fakes_dir = temp_dir / "fakes"
+    shutil.copytree(FAKES_DIR, fakes_dir)
+    for fake in fakes_dir.iterdir():
+        fake.chmod(0o755)
+
+    try:
+        runner.container = runner.client.containers.run(
+            BASE_IMAGE,
+            command=["/bin/bash", "-c", "tail -f /dev/null"],
+            detach=True,
+            volumes={
+                str(package_dir): {"bind": "/skyhook-package", "mode": "rw"},
+                str(fakes_dir): {"bind": FAKE_BIN, "mode": "ro"},
+            },
+            remove=False,
+            tty=False,
+            stdin_open=False,
+        )
+        _wait_until_ready(runner)
+        yield runner
+    finally:
+        runner.cleanup()
+
+
+def _wait_until_ready(runner: DockerTestRunner, timeout: float = 60.0):
+    probe = "test -f /skyhook-package/config.json && test -x /fakes/systemctl"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if runner.container.exec_run(["/bin/bash", "-c", probe]).exit_code == 0:
+                return
+        except Exception:
+            pass
+        time.sleep(0.25)
+    raise RuntimeError("container never became ready")
+
+
+def sh(node: DockerTestRunner, command: str, env: dict = None) -> int:
+    return node.container.exec_run(
+        ["/bin/bash", "-c", command], workdir="/", environment=env or {}
+    ).exit_code
+
+
+def step(node: DockerTestRunner, script: str, env: dict = None) -> int:
+    step_env = dict(STEP_ENV)
+    if env:
+        step_env.update(env)
+    return node.container.exec_run(
+        ["/bin/bash", "-c", f"/skyhook-package/skyhook_dir/{script} > {OUTPUT_FILE} 2>&1"],
+        workdir="/skyhook-package",
+        environment=step_env,
+    ).exit_code
+
+
+def quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def said(node: DockerTestRunner, text: str) -> bool:
+    return sh(node, f"grep -qF {quote(text)} {OUTPUT_FILE}") == 0
+
+
+def output(node: DockerTestRunner) -> str:
+    return node.container.exec_run(["cat", OUTPUT_FILE]).output.decode(
+        "utf-8", errors="replace"
+    )
+
+
+def exists(node: DockerTestRunner, path: str) -> bool:
+    return sh(node, f"test -e {path}") == 0
+
+
+def configure(node: DockerTestRunner, **configmaps):
+    cmds = ["rm -rf /skyhook-package/configmaps", "mkdir -p /skyhook-package/configmaps"]
+    for key, value in configmaps.items():
+        cmds.append(f"printf '%s' {quote(value)} > /skyhook-package/configmaps/{key}")
+    assert sh(node, " && ".join(cmds)) == 0
+
+
+def start_foreign_daemon(node: DockerTestRunner, rail: str):
+    """Start a process indistinguishable from a real foreign doca_spcx_cc.
+
+    The guard matches on `pgrep -x`, which compares /proc/pid/comm. comm follows the
+    executable, so a shell-script double is reported as `bash` and would not be found.
+    Copying an ELF binary gives the right comm, and `exec -a` supplies a cmdline in the
+    real daemon's shape so the rail can be parsed out of it.
+    """
+    assert sh(node, "cp /usr/bin/sleep /usr/local/bin/doca_spcx_cc") == 0
+    # argv0 travels via the environment so it does not have to survive nested quoting.
+    assert (
+        sh(
+            node,
+            "setsid nohup bash -c 'exec -a \"$FOREIGN_ARGV0\" "
+            "/usr/local/bin/doca_spcx_cc 3600' >/dev/null 2>&1 < /dev/null & sleep 1",
+            env={"FOREIGN_ARGV0": f"doca_spcx_cc -d {rail} -w -1"},
+        )
+        == 0
+    )
+
+
+def stage_rails(node: DockerTestRunner, count: int = 4):
+    """Fake /sys/class/infiniband matching what a real GB300 node presents.
+
+    Bonded PFs have no physfn; the host's own mlx5_0..3 are VFs and do have one.
+    """
+    cmds = [f"rm -rf {IB_DIR} /tmp/pci", f"mkdir -p {IB_DIR} /tmp/pci"]
+    for i in range(count):
+        # `device` is a symlink to the PCI node on a real host; the script resolves it
+        # to a BDF for the firmware query.
+        bdf = f"{i:04d}:03:00.0"
+        cmds.append(f"mkdir -p /tmp/pci/{bdf}")
+        cmds.append(f"mkdir -p {IB_DIR}/mlx5_bond_{i}")
+        cmds.append(f"ln -sfn /tmp/pci/{bdf} {IB_DIR}/mlx5_bond_{i}/device")
+    # Host VFs: same shape as the real node, physfn present.
+    for i in range(4):
+        cmds.append(f"mkdir -p {IB_DIR}/mlx5_{i}/device/physfn")
+    assert sh(node, " && ".join(cmds)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("configmaps", OTHER_SHAPES, ids=OTHER_SHAPE_IDS)
+def test_spcx_cc_is_a_noop_for_other_shapes(node, configmaps):
+    configure(node, **configmaps)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, RULES_DEST)
+
+    assert step(node, "configure_spcx_cc_check.sh") == 0, output(node)
+    assert said(node, "nothing to verify"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# Switched off: must never require DOCA
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["off", "OFF", "false", "0", "no"])
+def test_spcx_cc_off_does_not_require_doca(node, value):
+    """A node that opted out must not need the dependency installed."""
+    configure(node, spcx_cc=value, **OCI_GB300)
+    stage_rails(node)
+
+    # No DOCA binary anywhere on PATH.
+    rc = step(node, "configure_spcx_cc.sh", {"DOCA_SPCX_CC_BIN": "/nonexistent/doca_spcx_cc"})
+    assert rc == 0, output(node)
+    assert said(node, "switched off"), output(node)
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, RULES_DEST)
+
+    rc = step(
+        node, "configure_spcx_cc_check.sh", {"DOCA_SPCX_CC_BIN": "/nonexistent/doca_spcx_cc"}
+    )
+    assert rc == 0, output(node)
+    assert said(node, "is off"), output(node)
+
+
+def test_spcx_cc_off_tears_down_a_previously_enabled_node(node):
+    """Flipping the key off must stop the units, not merely skip."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert exists(node, UNIT_DEST)
+    assert exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service")
+
+    configure(node, spcx_cc="off", **OCI_GB300)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, RULES_DEST)
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service")
+    assert step(node, "configure_spcx_cc_check.sh") == 0, output(node)
+
+
+# ---------------------------------------------------------------------------
+# Switched on
+# ---------------------------------------------------------------------------
+
+
+def test_spcx_cc_defaults_to_on_when_the_key_is_absent(node):
+    configure(node, **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert said(node, "running on 4 rail(s)"), output(node)
+
+
+def test_spcx_cc_on_installs_unit_and_rule_and_starts_each_rail(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert sh(node, f"cmp -s {BUNDLED_DIR}/doca-spcx-cc@.service {UNIT_DEST}") == 0
+    assert sh(node, f"cmp -s {BUNDLED_DIR}/99-doca-spcx-cc.rules {RULES_DEST}") == 0
+
+    for i in range(4):
+        unit = f"doca-spcx-cc@mlx5_bond_{i}.service"
+        assert exists(node, f"/tmp/fake-systemctl/enabled.{unit}"), f"{unit} not enabled"
+        assert exists(node, f"/tmp/fake-systemctl/active.{unit}"), f"{unit} not started"
+
+    # The VF device must not have been targeted.
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_0.service")
+    assert sh(node, "grep -q 'control' /tmp/fake-udev/calls") == 0
+
+
+def test_spcx_cc_on_fails_clearly_when_doca_is_missing(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    rc = step(node, "configure_spcx_cc.sh", {"DOCA_SPCX_CC_BIN": "/nonexistent/doca_spcx_cc"})
+    assert rc != 0
+    assert said(node, "cannot be started"), output(node)
+    assert said(node, "not present or not executable"), output(node)
+    assert said(node, 'spcx_cc: "off"'), output(node)
+    assert not exists(node, UNIT_DEST), "must not install a unit it cannot run"
+
+
+def test_spcx_cc_is_idempotent(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert step(node, "configure_spcx_cc_check.sh") == 0, output(node)
+
+
+def test_spcx_cc_fails_loudly_when_no_bonded_pfs_are_found(node):
+    """The bond naming is an assumption; if it does not hold, say so rather than no-op.
+
+    Bonded PFs are created by the mlx5 driver at load, so a node that has any has them
+    before this runs. Finding none means the device naming is not what is expected, and
+    the diagnostic has to show what is actually present.
+    """
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node, count=0)
+
+    assert step(node, "configure_spcx_cc.sh") != 0
+    assert said(node, "no mlx5_bond_* devices found"), output(node)
+    # The non-bond device staged by stage_rails must be listed so the operator can see
+    # what the node actually presents.
+    assert said(node, "mlx5_0"), output(node)
+    assert said(node, "RAIL_GLOB"), output(node)
+
+
+def test_spcx_cc_rail_glob_is_overridable(node):
+    """Escape hatch for a node whose RDMA devices were renamed."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    cmds = [
+        f"rm -rf {IB_DIR}",
+        f"mkdir -p {IB_DIR}/rdma_rail0/device {IB_DIR}/rdma_rail1/device",
+        f"mkdir -p {IB_DIR}/mlx5_0/device/physfn",
+    ]
+    assert sh(node, " && ".join(cmds)) == 0
+
+    assert step(node, "configure_spcx_cc.sh", {"RAIL_GLOB": "rdma_rail*"}) == 0, output(node)
+    assert said(node, "running on 2 rail(s)"), output(node)
+    assert exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@rdma_rail0.service")
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_0.service")
+
+
+def test_spcx_cc_never_targets_a_virtual_function(node):
+    """A rename can leave a VF matching a pattern meant for PFs; physfn is the guard."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    cmds = [
+        f"rm -rf {IB_DIR}",
+        # Renamed devices where one is really a VF.
+        f"mkdir -p {IB_DIR}/rdma_rail0/device",
+        f"mkdir -p {IB_DIR}/rdma_rail1/device/physfn",
+    ]
+    assert sh(node, " && ".join(cmds)) == 0
+
+    assert step(node, "configure_spcx_cc.sh", {"RAIL_GLOB": "rdma_rail*"}) == 0, output(node)
+    assert said(node, "running on 1 rail(s)"), output(node)
+    assert said(node, "rdma_rail1: it is a virtual function"), output(node)
+    assert exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@rdma_rail0.service")
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@rdma_rail1.service")
+
+
+def test_spcx_cc_ignores_host_vfs_with_a_broad_glob(node):
+    """Even mlx5_* must not start congestion control on the host's own VFs."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh", {"RAIL_GLOB": "mlx5_*"}) == 0, output(node)
+    for i in range(4):
+        assert not exists(node, f"/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_{i}.service")
+        assert exists(node, f"/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_{i}.service")
+
+
+# ---------------------------------------------------------------------------
+# Foreign process guard
+# ---------------------------------------------------------------------------
+
+
+def test_spcx_cc_refuses_when_another_owner_is_already_running(node):
+    """Two owners would give a rail two processes; the tool requires exactly one."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    start_foreign_daemon(node, "mlx5_bond_0")
+
+    rc = step(node, "configure_spcx_cc.sh")
+    assert rc != 0
+    assert said(node, "already running outside this package"), output(node)
+    assert said(node, "mlx5_bond_0"), output(node)
+    assert not exists(node, UNIT_DEST), "must not install while a foreign owner runs"
+
+
+def test_spcx_cc_foreign_guard_reports_discovered_state_not_assumed_names(node):
+    """The remedy must not name units invented elsewhere; report what was found."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    start_foreign_daemon(node, "mlx5_bond_2")
+
+    assert step(node, "configure_spcx_cc.sh") != 0
+    assert said(node, "rail mlx5_bond_2"), output(node)
+    # No systemd in the test container, so the owner is reported as absent rather than guessed.
+    assert said(node, "<no systemd unit>"), output(node)
+    assert not said(node, "doca-spcx-cc-rail0"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# Check behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_spcx_cc_check_fails_when_a_rail_never_reports_ready(node):
+    """Unit active is not the same as PCC engaged."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+
+    rc = step(node, "configure_spcx_cc_check.sh", {"FAKE_JOURNAL_NEVER_READY": "1"})
+    assert rc != 0
+    assert said(node, "did not report"), output(node)
+
+
+def test_spcx_cc_check_fails_when_the_unit_is_missing(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc_check.sh") != 0
+    assert said(node, "unit template missing"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_spcx_cc_uninstall_removes_unit_and_rule(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+
+    assert step(node, "uninstall_spcx_cc.sh") == 0, output(node)
+    assert not exists(node, UNIT_DEST)
+    assert not exists(node, RULES_DEST)
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service")
+    assert step(node, "uninstall_spcx_cc_check.sh") == 0, output(node)
+
+
+def test_spcx_cc_uninstall_is_a_noop_when_never_installed(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "uninstall_spcx_cc.sh") == 0, output(node)
+    assert said(node, "nothing to stop"), output(node)
+    assert step(node, "uninstall_spcx_cc_check.sh") == 0, output(node)
+
+
+def test_spcx_cc_uninstall_does_not_need_doca(node):
+    """Teardown must work on a node where DOCA was removed or never installed."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+
+    rc = step(node, "uninstall_spcx_cc.sh", {"DOCA_SPCX_CC_BIN": "/nonexistent/doca_spcx_cc"})
+    assert rc == 0, output(node)
+    assert step(node, "uninstall_spcx_cc_check.sh") == 0, output(node)
+
+
+# ---------------------------------------------------------------------------
+# Firmware prerequisite
+# ---------------------------------------------------------------------------
+
+
+def test_spcx_cc_reports_firmware_state_when_enabled(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert said(node, "USER_PROGRAMMABLE_CC=True(1)"), output(node)
+    # The unenforced knobs are still surfaced for diagnostics.
+    assert said(node, "PCC_INT_EN=False(0)"), output(node)
+    assert said(node, "ROCE_ADAPTIVE_ROUTING_EN=True(1)"), output(node)
+
+
+def test_spcx_cc_fails_when_user_programmable_cc_is_disabled(node):
+    """Firmware that disallows a programmable algorithm is a missing dependency."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    rc = step(node, "configure_spcx_cc.sh", {"FAKE_USER_PROGRAMMABLE_CC": "False(0)"})
+    assert rc != 0
+    assert said(node, "USER_PROGRAMMABLE_CC is False(0), need True(1)"), output(node)
+    assert said(node, "would run without doing anything useful"), output(node)
+    assert said(node, 'spcx_cc: "off"'), output(node)
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service")
+    # Nothing may be written to the host until every prerequisite has cleared: a udev
+    # rule left behind would still instantiate units on the next device event.
+    assert not exists(node, UNIT_DEST), "must not install a unit it cannot run"
+    assert not exists(node, RULES_DEST), "must not leave a rule that could start it later"
+
+
+def test_spcx_cc_fails_when_only_one_rail_has_bad_firmware(node):
+    """A partially configured node must not come up half enabled."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    rc = step(node, "configure_spcx_cc.sh", {"FAKE_MLXCONFIG_DEVICE_FAIL": "0002:03:00.0"})
+    assert rc != 0
+    assert said(node, "mlx5_bond_2 (0002:03:00.0)"), output(node)
+    assert not exists(node, "/tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service")
+
+
+def test_spcx_cc_fails_when_mlxconfig_is_absent(node):
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+
+    rc = step(node, "configure_spcx_cc.sh", {"MLXCONFIG_BIN": "mlxconfig_absent"})
+    assert rc != 0
+    assert said(node, "prerequisites cannot be checked"), output(node)
+    assert said(node, "firmware tools"), output(node)
+
+
+def test_spcx_cc_off_ignores_firmware_entirely(node):
+    """Disabled feature must not care about any dependency, firmware included."""
+    configure(node, spcx_cc="off", **OCI_GB300)
+    stage_rails(node)
+
+    rc = step(
+        node,
+        "configure_spcx_cc.sh",
+        {
+            "MLXCONFIG_BIN": "mlxconfig_absent",
+            "DOCA_SPCX_CC_BIN": "/nonexistent/doca_spcx_cc",
+            "FAKE_USER_PROGRAMMABLE_CC": "False(0)",
+        },
+    )
+    assert rc == 0, output(node)
+    assert said(node, "switched off"), output(node)
+
+
+def test_spcx_cc_off_tolerates_processes_owned_by_something_else(node):
+    """Off means this package takes no part, not that nothing else may run PCC.
+
+    Found on a real node: a hand-started daemon made the off-state check fail, which
+    contradicts the contract that a disabled feature cannot fail the package.
+    """
+    configure(node, spcx_cc="off", **OCI_GB300)
+    stage_rails(node)
+    start_foreign_daemon(node, "mlx5_bond_0")
+
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert step(node, "configure_spcx_cc_check.sh") == 0, output(node)
+    assert said(node, "is off"), output(node)
+    assert said(node, "running from outside this package"), output(node)


### PR DESCRIPTION
## Description

Runs DOCA Spectrum-X congestion control on GB300 nodes as a supervised systemd service,
so the state survives a reboot.

Congestion control is normally started by hand with `systemd-run`, which creates
transient units under `/run/systemd/transient`. Those do not survive a reboot, and there
is no unit file to enable, so a rebooted node silently drops out of congestion control.

### How

New `config` step `configure-spcx-cc` installs a `doca-spcx-cc@.service` template and a
udev rule, then starts one instance per RDMA bond. A template unit makes the tool's
"exactly one process per rail" requirement structural, since systemd allows only one
instance per device name. Binding instances to devices via udev covers both boot and an
mlx5 driver reload that recreates the device, which a one-shot enumeration would not.

The daemon invocation is unchanged from the documented one: `doca_spcx_cc -d <rail> -w -1`
with `Restart=on-failure` and `RestartSec=5s`. Only the supervision differs.

The unit is not ordered before kubelet: congestion control affects network performance,
not node readiness, so it cannot strand a node.

### Toggle and prerequisites

`spcx_cc` configMap key, defaulting to on. A configMap key rather than an env var because
the operator diffs configMap keys into `status.ConfigUpdates`, so flipping it re-runs the
step and can drive a `configInterrupts` entry; env changes do not. A falsey value tears
the units down rather than skipping, so the toggle works both ways.

Two prerequisites are enforced only when the feature is on, and never consulted when it
is off:

| Prerequisite | Behaviour when on |
|---|---|
| `doca_spcx_cc` binary | missing fails the package |
| `USER_PROGRAMMABLE_CC=True(1)` per rail | not set fails the package |

A node with `spcx_cc: "off"` needs neither. Firmware is read, never written.

The step also refuses to start when congestion control is already running from something
this package did not start, rather than giving a rail two processes. The error reports
the processes, rails, and owning units it actually found.

## Notes for reviewers

- **Default is on**, so an existing `oci`/`gb300` deployment starts running congestion
  control on upgrade with no CR change. Called out as an upgrade note in RELEASE_NOTES.
- **Only `USER_PROGRAMMABLE_CC` is enforced**, not every congestion control knob. Their
  required values are not established, and `PCC_INT_EN` reads `False(0)` on a node where
  congestion control works, so enforcing the observed set would fail healthy nodes. The
  rest are reported in step output.
- **Device selection is by name and structure.** The default glob is `mlx5_bond_*`, which
  is what `mlx5_ib` names a device when hardware LAG is active. `RAIL_GLOB` overrides it
  for renamed devices, and devices with a `physfn` are skipped whatever the glob matches,
  so a rename cannot cause a VF to be targeted.
- **Rollout**: nodes already running hand-started congestion control will be refused until
  those units are stopped, or until they reboot, which clears transient units.

## Testing

30 integration tests covering gating, both toggle directions, both prerequisites, the
foreign-owner refusal, rail discovery and VF exclusion, readiness, and uninstall.

Also exercised end to end on a GB300 node by stopping the hand-started units and running
the steps directly:

- refusal path leaves nothing on the host
- firmware gate passes per rail with addresses resolved from sysfs
- four instances start, are `enabled`, and are owned by the template
- the check matches the daemon's own `PCC host status Active` line
- `udevadm test` instantiates the unit for a bond and not for a VF
- switched off with congestion control running from elsewhere: passes and leaves it alone
- uninstall removes only this package's artifacts

That last case was a bug found on hardware: the off-state check failed when another owner
was running, which contradicts a disabled feature never failing a node. Fixed, with a
regression test.

`shellcheck` clean, `make license-check` and `make validate-inherited` pass. Bumps
package_version to 0.7.0.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
