### PR TITLE
fix(nvidia-tuned): verify PCIe ACS independently of GPU driver state

### DIFF
--- a/nvidia-tuned/CHANGELOG.md
+++ b/nvidia-tuned/CHANGELOG.md
@@ -5,12 +5,23 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.7.1] - 2026-08-10
+
+### Bug Fixes
+
+- *(nvidia-tuned)* Verify PCIe ACS independently of GPU driver state
+- *(nvidia-tuned)* Require an ACS result record before accepting ACS values
+
+
 ## [0.7.0] - 2026-08-10
 
 ### New Features
 
 - *(nvidia-tuned)* Run DOCA Spectrum-X congestion control on OCI GB300 
 
+### Other Tasks
+
+- *(nvidia-tuned)* Update changelog for nvidia-tuned 
 
 ## [0.6.0] - 2026-08-10
 

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -412,7 +412,7 @@ See the [tuned package README](../tuned/README.md) for complete documentation on
 
 ## Version
 
-- **Package Version**: 0.7.0
+- **Package Version**: 0.7.1
 - **Base Package**: tuned (latest via preprocess.sh)
 - **Schema Version**: v1
 

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,16 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.7.1
+
+Fixes the PCIe ACS checks rejecting a node whose GPU driver is not loaded.
+
+`rdma_topo check` also asserts GPU and DMA iommu_group topology, and the checks keyed on
+its exit code. On a new cluster that cannot succeed: Skyhook taints the node, the GPU
+operator cannot install drivers until Skyhook completes, and Skyhook cannot complete
+while the post-interrupt check waits on the driver. The checks now gate on the tool's
+ACS lines, so correct ACS passes regardless of driver state while wrong ACS still fails.
+
 ## 0.7.0
 
 Adds DOCA Spectrum-X congestion control for GB300 nodes on OCI.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.7.0",
+    "package_version": "0.7.1",
     "expected_config_files": [
         "accelerator"
     ],

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
@@ -92,8 +92,11 @@ acs_enabled() {
 acs_values_correct() {
     local out
     out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
-    grep -q "ACS" <<< "${out}" || return 1
-    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+    # An ACS result record must be present. Merely mentioning ACS is not evidence: a
+    # diagnostic such as "ACS query unavailable" would otherwise pass the presence test,
+    # match no FAIL, and report unreadable state as correct.
+    grep -qE "^(OK|FAIL)[[:space:]]+ACS([[:space:]]|$)" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS([[:space:]]|$)" <<< "${out}"
 }
 
 # Regenerate the bootloader config. Mirrors the fallback chain in kdump's

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs.sh
@@ -79,6 +79,23 @@ acs_enabled() {
     [[ -f "${PROFILES_DIR}/service/${service}/pcie-acs-${accelerator}.enabled" ]]
 }
 
+# True when the PCIe ACS values are correct.
+#
+# Gates on the ACS lines rather than the tool's exit code. `rdma_topo check` also
+# asserts GPU and DMA iommu_group topology, which requires the GPU driver to be loaded.
+# That is not something this package controls, and on a new cluster it cannot be true
+# yet: Skyhook taints the node, the GPU operator cannot install drivers until Skyhook
+# completes, and Skyhook cannot complete while this check waits on the driver. Keying on
+# the exit code deadlocks bringup.
+#
+# Requires at least one ACS line, so a tool that failed to run is not read as success.
+acs_values_correct() {
+    local out
+    out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
+    grep -q "ACS" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+}
+
 # Regenerate the bootloader config. Mirrors the fallback chain in kdump's
 # update_grub_config().
 regenerate_grub() {
@@ -116,7 +133,7 @@ main() {
     # `rdma_topo check` reads the live kernel state, so it keeps failing between the
     # grub write and the reboot. Re-running write-grub-acs in that window is harmless:
     # the tool regenerates the same drop-in from the same topology.
-    if "${RDMA_TOPO_BIN}" check; then
+    if acs_values_correct; then
         echo "PCIe ACS values are already correct; nothing to do"
         return 0
     fi

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -36,6 +36,23 @@ PROFILES_DIR="${SKYHOOK_DIR}/profiles"
 ACS_GRUB_DROPIN="${ACS_GRUB_DROPIN:-/etc/default/grub.d/config-acs.cfg}"
 RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
 
+# True when the PCIe ACS values are correct.
+#
+# Gates on the ACS lines rather than the tool's exit code. `rdma_topo check` also
+# asserts GPU and DMA iommu_group topology, which requires the GPU driver to be loaded.
+# That is not something this package controls, and on a new cluster it cannot be true
+# yet: Skyhook taints the node, the GPU operator cannot install drivers until Skyhook
+# completes, and Skyhook cannot complete while this check waits on the driver. Keying on
+# the exit code deadlocks bringup.
+#
+# Requires at least one ACS line, so a tool that failed to run is not read as success.
+acs_values_correct() {
+    local out
+    out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
+    grep -q "ACS" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+}
+
 # Mirrors acs_requested() in configure_pcie_acs.sh.
 acs_requested() {
     local setting
@@ -77,7 +94,7 @@ main() {
         exit 1
     fi
 
-    if "${RDMA_TOPO_BIN}" check; then
+    if acs_values_correct; then
         echo "Verified PCIe ACS values are correct"
         return 0
     fi

--- a/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_pcie_acs_check.sh
@@ -49,8 +49,11 @@ RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
 acs_values_correct() {
     local out
     out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
-    grep -q "ACS" <<< "${out}" || return 1
-    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+    # An ACS result record must be present. Merely mentioning ACS is not evidence: a
+    # diagnostic such as "ACS query unavailable" would otherwise pass the presence test,
+    # match no FAIL, and report unreadable state as correct.
+    grep -qE "^(OK|FAIL)[[:space:]]+ACS([[:space:]]|$)" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS([[:space:]]|$)" <<< "${out}"
 }
 
 # Mirrors acs_requested() in configure_pcie_acs.sh.

--- a/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
@@ -48,8 +48,11 @@ PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
 acs_values_correct() {
     local out
     out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
-    grep -q "ACS" <<< "${out}" || return 1
-    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+    # An ACS result record must be present. Merely mentioning ACS is not evidence: a
+    # diagnostic such as "ACS query unavailable" would otherwise pass the presence test,
+    # match no FAIL, and report unreadable state as correct.
+    grep -qE "^(OK|FAIL)[[:space:]]+ACS([[:space:]]|$)" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS([[:space:]]|$)" <<< "${out}"
 }
 
 # Mirrors acs_requested() in configure_pcie_acs.sh.

--- a/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_pcie_acs_check.sh
@@ -35,6 +35,23 @@ PROFILES_DIR="${SKYHOOK_DIR}/profiles"
 RDMA_TOPO_BIN="${RDMA_TOPO_BIN:-rdma_topo}"
 PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
 
+# True when the PCIe ACS values are correct.
+#
+# Gates on the ACS lines rather than the tool's exit code. `rdma_topo check` also
+# asserts GPU and DMA iommu_group topology, which requires the GPU driver to be loaded.
+# That is not something this package controls, and on a new cluster it cannot be true
+# yet: Skyhook taints the node, the GPU operator cannot install drivers until Skyhook
+# completes, and Skyhook cannot complete while this check waits on the driver. Keying on
+# the exit code deadlocks bringup.
+#
+# Requires at least one ACS line, so a tool that failed to run is not read as success.
+acs_values_correct() {
+    local out
+    out="$("${RDMA_TOPO_BIN}" check 2>&1 || true)"
+    grep -q "ACS" <<< "${out}" || return 1
+    ! grep -qE "^FAIL[[:space:]]+ACS" <<< "${out}"
+}
+
 # Mirrors acs_requested() in configure_pcie_acs.sh.
 acs_requested() {
     local setting
@@ -75,7 +92,7 @@ main() {
         fail_acs_not_applied "${RDMA_TOPO_BIN} is not installed on this node, so the ACS values cannot be read."
     fi
 
-    if ! "${RDMA_TOPO_BIN}" check; then
+    if ! acs_values_correct; then
         if grep -q "config_acs" "${PROC_CMDLINE}"; then
             fail_acs_not_applied \
                 "The booted kernel command line carries the config_acs argument but the ACS values are still wrong, so the kernel did not act on it. This is what a kernel without pci=config_acs= support looks like."

--- a/tests/integration/nvidia_tuned/fakes/rdma_topo
+++ b/tests/integration/nvidia_tuned/fakes/rdma_topo
@@ -18,9 +18,13 @@
 
 # Test double for the rdma_topo tool that ships in the OCI GB300 node image.
 #
-# FAKE_RDMA_TOPO_CHECK=pass  -> `check` succeeds
-# FAKE_RDMA_TOPO_CHECK=fail  -> `check` fails (the stock GB300 state); default
-# FAKE_RDMA_TOPO_CHECK=fix   -> `check` fails until write-grub-acs has run, then succeeds
+# FAKE_RDMA_TOPO_CHECK=pass    -> ACS lines all OK
+# FAKE_RDMA_TOPO_CHECK=fail    -> ACS lines report FAIL (the stock GB300 state); default
+# FAKE_RDMA_TOPO_CHECK=fix     -> ACS FAILs until write-grub-acs has run, then OK
+# FAKE_RDMA_TOPO_CHECK=nogpu   -> ACS all OK, but the GPU iommu_group assertion fails
+#                                 and the tool exits non-zero. This is a node whose GPU
+#                                 driver is not loaded, which on a new cluster is every
+#                                 node until Skyhook completes.
 
 set -euo pipefail
 
@@ -32,19 +36,26 @@ echo "$*" >> "${STATE_DIR}/calls"
 
 case "${1:-}" in
     check)
-        case "${FAKE_RDMA_TOPO_CHECK:-fail}" in
+        setting="${FAKE_RDMA_TOPO_CHECK:-fail}"
+        if [[ "${setting}" == "fix" && -f "${STATE_DIR}/wrote-grub-acs" ]]; then
+            setting="pass"
+        fi
+
+        case "${setting}" in
             pass)
-                echo "PASS ACS for grace_rp 0008:00:00.0"
+                echo "OK	All ConnectX DMA functions have correct PCI topology"
+                echo "OK	ACS for grace_rp 0008:00:00.0 has correct values 0011100 = xx111x0"
                 exit 0
                 ;;
-            fix)
-                if [[ -f "${STATE_DIR}/wrote-grub-acs" ]]; then
-                    echo "PASS ACS for grace_rp 0008:00:00.0"
-                    exit 0
-                fi
+            nogpu)
+                # ACS is correct; only the GPU topology assertion fails, and the tool
+                # still exits non-zero. Keying on the exit code would reject this node.
+                echo "OK	ACS for grace_rp 0008:00:00.0 has correct values 0011100 = xx111x0"
+                echo "FAIL	Kernel iommu_group for DMA 0009:03:00.0 and GPU 0009:06:00.0 are not equal 29 != None"
+                exit 1
                 ;;
         esac
-        echo "FAIL ACS for grace_rp 0008:00:00.0 has incorrect values 0011101 != xx111x0 (0x1d != 0x1c)" >&2
+        echo "FAIL	ACS for grace_rp 0008:00:00.0 has incorrect values 0011101 != xx111x0 (0x1d != 0x1c)"
         exit 1
         ;;
     write-grub-acs)

--- a/tests/integration/nvidia_tuned/fakes/rdma_topo
+++ b/tests/integration/nvidia_tuned/fakes/rdma_topo
@@ -25,6 +25,8 @@
 #                                 and the tool exits non-zero. This is a node whose GPU
 #                                 driver is not loaded, which on a new cluster is every
 #                                 node until Skyhook completes.
+# FAKE_RDMA_TOPO_CHECK=unreadable -> mentions ACS in a diagnostic but emits no ACS
+#                                 result record. Unreadable state must not read as OK.
 
 set -euo pipefail
 
@@ -46,6 +48,10 @@ case "${1:-}" in
                 echo "OK	All ConnectX DMA functions have correct PCI topology"
                 echo "OK	ACS for grace_rp 0008:00:00.0 has correct values 0011100 = xx111x0"
                 exit 0
+                ;;
+            unreadable)
+                echo "rdma_topo: ACS query unavailable"
+                exit 1
                 ;;
             nogpu)
                 # ACS is correct; only the GPU topology assertion fails, and the tool

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -628,3 +628,43 @@ def test_pcie_acs_stays_on_for_any_non_falsey_value(node, value):
     assert rc == 0, output(node)
     assert said(node, "reboot is required"), output(node)
     assert exists(node, ACS_DROPIN)
+
+
+# ---------------------------------------------------------------------------
+# ACS verification must not depend on GPU driver state
+# ---------------------------------------------------------------------------
+
+
+def test_pcie_acs_accepts_correct_acs_when_the_gpu_driver_is_absent(node):
+    """`rdma_topo check` also asserts GPU topology, which this package does not control.
+
+    On a new cluster this is every node: Skyhook taints it, the GPU operator cannot
+    install drivers until Skyhook completes, and Skyhook cannot complete if this check
+    waits on the driver. Keying on the tool's exit code deadlocks bringup, so the checks
+    gate on the ACS lines instead.
+    """
+    configure(node, **OCI_GB300)
+    nogpu = {"FAKE_RDMA_TOPO_CHECK": "nogpu"}
+
+    # Correct ACS is recognised, so no bootloader rewrite is attempted.
+    assert step(node, "configure_pcie_acs.sh", nogpu) == 0, output(node)
+    assert said(node, "already correct"), output(node)
+    assert not exists(node, ACS_DROPIN)
+
+    assert step(node, "configure_pcie_acs_check.sh", nogpu) == 0, output(node)
+    assert said(node, "values are correct"), output(node)
+
+    # The post-interrupt check is the one that would have deadlocked a new cluster.
+    assert step(node, "post_interrupt_pcie_acs_check.sh", nogpu) == 0, output(node)
+    assert said(node, "correct after reboot"), output(node)
+
+
+def test_pcie_acs_still_fails_when_acs_itself_is_wrong(node):
+    """Ignoring GPU topology must not weaken the ACS assertion."""
+    configure(node, **OCI_GB300)
+    failing = {"FAKE_RDMA_TOPO_CHECK": "fail"}
+
+    assert step(node, "configure_pcie_acs.sh", failing) == 0, output(node)
+    assert said(node, "reboot is required"), output(node)
+    assert step(node, "post_interrupt_pcie_acs_check.sh", failing) != 0
+    assert said(node, "did not take effect on this node"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -668,3 +668,17 @@ def test_pcie_acs_still_fails_when_acs_itself_is_wrong(node):
     assert said(node, "reboot is required"), output(node)
     assert step(node, "post_interrupt_pcie_acs_check.sh", failing) != 0
     assert said(node, "did not take effect on this node"), output(node)
+
+
+def test_pcie_acs_rejects_unreadable_acs_state(node):
+    """A diagnostic mentioning ACS is not an ACS result; unreadable must not pass."""
+    configure(node, **OCI_GB300)
+    unreadable = {"FAKE_RDMA_TOPO_CHECK": "unreadable"}
+
+    # Treated as "not correct", so the correction is attempted rather than skipped.
+    assert step(node, "configure_pcie_acs.sh", unreadable) == 0, output(node)
+    assert said(node, "reboot is required"), output(node)
+
+    # And it must not be reported as verified.
+    assert step(node, "post_interrupt_pcie_acs_check.sh", unreadable) != 0
+    assert said(node, "did not take effect on this node"), output(node)


### PR DESCRIPTION
## Description

The PCIe ACS checks keyed on the exit code of `rdma_topo check`, which also asserts GPU
and DMA iommu_group topology. That requires the GPU driver to be loaded, which this
package does not control.

On a new cluster this deadlocks: Skyhook taints the node, the GPU operator cannot install
drivers until Skyhook completes, and Skyhook cannot complete while the post-interrupt
check waits on the driver.

In existing cluster this doesn't immediately cause problems, because the nodes aren't tainted
and blocking driver install, the check eventually succeeds.

## Fix

The checks now gate on the tool's ACS lines: at least one must be present, so a tool that
failed to run is not read as success, and none may report `FAIL`. Correct ACS passes
regardless of driver state; wrong ACS still fails.

Applied to `configure_pcie_acs.sh`, its config-check, and the post-interrupt check.

## Testing

The `rdma_topo` double gains a `nogpu` mode reproducing correct ACS alongside a failing
GPU assertion and a non-zero exit. Two tests: that case passes all three steps, and a
genuinely wrong ACS still fails. Verified the first fails against the old exit-code
logic.

54 tests pass, shellcheck clean, license and validate pass. Bumps to 0.7.1.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
