### PR TITLE
chore(general/ci): bump all GitHub Actions to current Node 24 releases

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -71,7 +71,7 @@ runs:
   using: 'composite'
   steps:
     - name: Log in to the Container registry
-      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
@@ -125,20 +125,20 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}
         tags: ${{ inputs.tags }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
     - name: Build and push Docker image
       id: push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
       with:
         context: ${{ inputs.package_name }}
         push: ${{ inputs.push }}
@@ -149,7 +149,7 @@ runs:
 
     - name: Generate artifact attestation
       if: inputs.generate_attestation == 'true'
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
       with:
         subject-name: ${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}
         subject-digest: ${{ steps.push.outputs.digest }}
@@ -190,7 +190,7 @@ runs:
 
     - name: Upload image info
       if: inputs.save_image_info == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: image-info-${{ inputs.package_name }}
         path: /tmp/image-info/${{ inputs.package_name }}.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Keeps the pinned GitHub Actions current. Every `uses:` in this repo is pinned
+# to a commit SHA with a trailing `# vX.Y.Z` comment (see AGENTS.md); Dependabot
+# understands that convention and bumps the SHA and the comment together, which
+# is what makes SHA pinning maintainable rather than a thing that silently rots.
+#
+# Without this, actions drift until something forces the issue: the whole set
+# went stale enough to trip the Node 20 runtime deprecation before anyone
+# noticed.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    # "/" covers .github/workflows; the composite action needs its own entry
+    # because its `uses:` refs live in .github/actions/build-package/action.yml.
+    directories:
+      - "/"
+      - "/.github/actions/build-package"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - component/ci
+    # commitlint runs on the PR title and every commit, so Dependabot's default
+    # "Bump x from y to z" subject would fail CI. This makes it
+    # "chore(general/ci): bump x from y to z", which is a valid Conventional
+    # Commit with the scope this repo uses for CI-wide changes.
+    commit-message:
+      prefix: chore(general/ci)
+    # One PR for all action bumps rather than one per action. Keeps the review
+    # surface small and avoids five near-identical PRs every Monday.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - name: Install actionlint

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Extract package name from tag

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
@@ -82,10 +84,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # No GITHUB_TOKEN in this environment: preprocess.sh is package-supplied
+      # code, and neither existing script needs the token. The equivalent step in
+      # .github/actions/build-package does not pass it either.
       - name: Run preprocess script
         id: preprocess
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREPROCESS_SCRIPT="${{ inputs.package_name }}/preprocess.sh"
           if [ -f "$PREPROCESS_SCRIPT" ]; then

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -73,10 +73,10 @@ jobs:
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -99,20 +99,20 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}
           tags: ${{ inputs.tags }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ${{ inputs.package_name }}
           push: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: inputs.generate_attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image_name }}/${{ inputs.package_name }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload image info
         if: inputs.save_image_info
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: image-info-${{ inputs.package_name }}
           path: /tmp/image-info/${{ inputs.package_name }}.txt

--- a/.github/workflows/commit-linting.yaml
+++ b/.github/workflows/commit-linting.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           # Full history so commitlint can walk every commit in the PR range.
           fetch-depth: 0
 

--- a/.github/workflows/commit-linting.yaml
+++ b/.github/workflows/commit-linting.yaml
@@ -43,13 +43,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # Full history so commitlint can walk every commit in the PR range.
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           # commitlint 21 requires Node >= 22.12.
           node-version: 22

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Label by path
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -44,12 +44,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: stable
 

--- a/.github/workflows/lint-shellcheck.yaml
+++ b/.github/workflows/lint-shellcheck.yaml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Show shellcheck version
         run: shellcheck --version

--- a/.github/workflows/lint-shellcheck.yaml
+++ b/.github/workflows/lint-shellcheck.yaml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Show shellcheck version
         run: shellcheck --version

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Detect changed packages
@@ -92,6 +93,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check if package changed and config.json exists
@@ -186,6 +188,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check if package changed
@@ -241,6 +244,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Get latest tag and short SHA

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -34,7 +34,7 @@ jobs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -184,7 +184,7 @@ jobs:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -239,7 +239,7 @@ jobs:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -290,7 +290,7 @@ jobs:
     steps:
       - name: Download all image info artifacts
         if: needs.build.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: image-info-*
           path: /tmp/image-info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       contents: write  # required for gh release create
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # full history needed for git-cliff to walk all tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0  # full history needed for git-cliff to walk all tags
 
       # Tags are <package>/<version> — extract the package name from the left side.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.1.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:
           # Issue settings
           stale-issue-message: |


### PR DESCRIPTION
## Why

Actions runners now force Node 20 actions onto Node 24 and warn about it on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4, docker/build-push-action@v6,
docker/login-action@65b78e6..., docker/metadata-action@9ec57ed...,
docker/setup-buildx-action@v3, docker/setup-qemu-action@v3
```

Every action in the repo except `github-script` and `cosign-installer` was affected. This bumps all of them and repins to commit SHAs.

## What changed

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v7.0.1** |
| `actions/setup-node` | v4 | **v7.0.0** |
| `actions/setup-go` | v5.6.0 | **v7.0.0** |
| `actions/upload-artifact` | v4 | **v7.0.1** |
| `actions/download-artifact` | v4 | **v8.0.1** |
| `actions/labeler` | v6.1.0 | **v7.0.0** |
| `actions/stale` | v10.1.0 | **v11.0.0** |
| `actions/attest-build-provenance` | v4.1.0 | **v4.2.2** |
| `docker/metadata-action` | v5 | **v6.2.0** |
| `docker/login-action` | v3 | **v4.6.0** |
| `docker/setup-qemu-action` | v3 | **v4.2.0** |
| `docker/setup-buildx-action` | v3 | **v4.2.0** |
| `docker/build-push-action` | v6 | **v7.3.0** |

`actions/github-script` (v9.0.0) and `sigstore/cosign-installer` (v4.1.2) were already current.

Everything is now pinned to a commit SHA with a trailing `# vX.Y.Z` comment, per `AGENTS.md`. 15 refs previously floated on a major tag, which is both unpinned and how they drifted this far behind in the first place.

## Breaking changes: checked, none apply

Several of these are multi-major jumps, so I checked each against how we actually use it:

- **`download-artifact` v5** changed output paths for single downloads **by ID**. We use `pattern:` + `merge-multiple:`, i.e. by name. Not affected.
- **`setup-node` v5** auto-caches when `package.json` has a `packageManager` field. This repo has no `package.json`; commitlint is installed with `npm install --no-save`. Not affected.
- **`build-push-action` v7** removes `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. Neither appears anywhere in `.github/`.
- **`setup-buildx` v4** removes deprecated inputs. We invoke it with no inputs at all.
- **`metadata-action` v6** changes `#` handling in list inputs. Our `tags:` values carry no `#`.
- **`labeler` v7 / `stale` v11 / `upload-artifact` v6 and v7** are ESM + Node 24 only.

All require Actions Runner >= 2.327.1, which GitHub-hosted runners already exceed.

## Dependabot

SHA pinning only stays useful if something bumps the pins. Nothing did, which is how the whole set rotted far enough to trip a runtime deprecation. `.github/dependabot.yml` now watches the `github-actions` ecosystem weekly.

Three things worth noting in that config:

- **Two directories.** `"/"` covers `.github/workflows`, but the composite action's own `uses:` refs live in `.github/actions/build-package/action.yml` and are not picked up otherwise.
- **`commit-message.prefix` is set.** commitlint runs on the PR title and every commit, and Dependabot's default `Bump x from y to z` subject is not a valid Conventional Commit, so its PRs would fail CI out of the box. The prefix makes them `chore(general/ci): bump ...`.
- **Grouped into a single PR**, so this is one review a week rather than five near-identical PRs.

## Verification

- [x] All 24 files under `.github/` parse as YAML
- [x] `actionlint` reports no new findings
- [x] `make license-check` clean
- [x] No floating action refs remain (`grep` for `@` without a 40-char SHA returns nothing)

Note that `build_container.yaml` and `release.yml` only run on tag push, so PR CI cannot exercise those paths. Their actions (`metadata-action`, `login-action`, `setup-qemu`, `setup-buildx`, `build-push-action`, `attest-build-provenance`, `cosign-installer`) are covered indirectly by `pr_build.yaml`, which builds through the same `build-package` composite action.
